### PR TITLE
fix: [SRTP-220] Gracefully handle DecodingException upon parsing badl…

### DIFF
--- a/src/main/java/it/gov/pagopa/rtp/activator/controller/rtp/RtpExceptionHandler.java
+++ b/src/main/java/it/gov/pagopa/rtp/activator/controller/rtp/RtpExceptionHandler.java
@@ -2,15 +2,22 @@ package it.gov.pagopa.rtp.activator.controller.rtp;
 
 import it.gov.pagopa.rtp.activator.domain.errors.MessageBadFormed;
 import it.gov.pagopa.rtp.activator.model.generated.send.MalformedRequestErrorResponseDto;
+import org.springframework.core.codec.DecodingException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.lang.NonNull;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.bind.support.WebExchangeBindException;
 
+import java.util.Optional;
+
 @RestControllerAdvice(basePackages = "it.gov.pagopa.rtp.activator.controller.rtp")
 public class RtpExceptionHandler {
+
+  private static final String MALFORMED_REQUEST_ERROR_CODE = "Malformed request";
+
 
   @ExceptionHandler(MessageBadFormed.class)
   @ResponseStatus(HttpStatus.BAD_REQUEST)
@@ -35,4 +42,45 @@ public class RtpExceptionHandler {
         .map(error -> ResponseEntity.badRequest().body(error))
         .orElse(ResponseEntity.badRequest().build());
   }
+
+
+  /**
+   * Handles {@link DecodingException} exceptions thrown during the processing of requests.
+   * <p>
+   * This method captures the exception, extracts the most specific cause of the decoding error,
+   * and constructs an appropriate response containing error details. If the cause of the
+   * exception is null, a fallback message ("Malformed request") is used.
+   * </p>
+   *
+   * <p><strong>Behavior:</strong></p>
+   * <ul>
+   *   <li>Sets the HTTP status of the response to {@code 400 Bad Request}.</li>
+   *   <li>Extracts the localized error message from the exception's most specific cause.
+   *       If the cause is {@code null}, a default error code ("Malformed request") is used.</li>
+   *   <li>Creates a {@link MalformedRequestErrorResponseDto} object that encapsulates
+   *       the error details, including a generic error code ("Malformed request")
+   *       and a description of the decoding issue.</li>
+   *   <li>Returns a {@link ResponseEntity} containing the {@link MalformedRequestErrorResponseDto} as the response body.</li>
+   * </ul>
+   *
+   * @param ex the {@link DecodingException} thrown during request decoding, typically due to malformed input.
+   *           Must not be {@code null}.
+   * @return a {@link ResponseEntity} with status {@code 400 Bad Request}, containing a {@link MalformedRequestErrorResponseDto}
+   *         object that details the error.
+   */
+  @ExceptionHandler(DecodingException.class)
+  @ResponseStatus(HttpStatus.BAD_REQUEST)
+  public ResponseEntity<MalformedRequestErrorResponseDto> handleDecodingException(@NonNull final DecodingException ex) {
+    final var description = Optional.of(ex)
+            .map(DecodingException::getMostSpecificCause)
+            .map(Throwable::getLocalizedMessage)
+            .orElse(MALFORMED_REQUEST_ERROR_CODE);
+
+    final var errorsDto = new MalformedRequestErrorResponseDto()
+            .error(MALFORMED_REQUEST_ERROR_CODE)
+            .details(description);
+
+    return ResponseEntity.badRequest().body(errorsDto);
+  }
+
 }

--- a/src/test/java/it/gov/pagopa/rtp/activator/controller/rtp/RtpExceptionHandlerTest.java
+++ b/src/test/java/it/gov/pagopa/rtp/activator/controller/rtp/RtpExceptionHandlerTest.java
@@ -1,0 +1,65 @@
+package it.gov.pagopa.rtp.activator.controller.rtp;
+
+import it.gov.pagopa.rtp.activator.model.generated.send.MalformedRequestErrorResponseDto;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.core.codec.DecodingException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class RtpExceptionHandlerTest {
+
+    private RtpExceptionHandler rtpExceptionHandler;
+
+
+    @BeforeEach
+    void setUp() {
+        rtpExceptionHandler = new RtpExceptionHandler();
+    }
+
+
+    @Test
+    void givenDecodingException_whenHandled_thenReturnsBadRequestWithErrorDetails() {
+        // Given
+        String specificCauseMessage = "Invalid JSON format";
+        DecodingException decodingException = Mockito.mock(DecodingException.class);
+        Throwable mostSpecificCause = Mockito.mock(Throwable.class);
+
+        Mockito.when(decodingException.getMostSpecificCause()).thenReturn(mostSpecificCause);
+        Mockito.when(mostSpecificCause.getLocalizedMessage()).thenReturn(specificCauseMessage);
+
+        // When
+        ResponseEntity<MalformedRequestErrorResponseDto> response = rtpExceptionHandler.handleDecodingException(decodingException);
+
+        // Then
+        assertNotNull(response, "Response should not be null");
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode(), "Status should be 400 Bad Request");
+        MalformedRequestErrorResponseDto errorDto = response.getBody();
+        assertNotNull(errorDto, "ErrorDto should not be null");
+        assertEquals("Malformed request", errorDto.getError(), "Errors should match");
+        assertEquals(specificCauseMessage, errorDto.getDetails(), "Error details should match the exception's message");
+    }
+
+    @Test
+    void givenDecodingException_whenCauseIsNull_thenReturnsBadRequestWithFallbackMessage() {
+        // Given
+        DecodingException decodingException = Mockito.mock(DecodingException.class);
+        Mockito.when(decodingException.getMostSpecificCause()).thenReturn(null);
+
+        // When
+        ResponseEntity<MalformedRequestErrorResponseDto> response = rtpExceptionHandler.handleDecodingException(decodingException);
+
+        // Then
+        assertNotNull(response, "Response should not be null");
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode(), "Status should be 400 Bad Request");
+        MalformedRequestErrorResponseDto errorDto = response.getBody();
+        assertNotNull(errorDto, "ErrorDto should not be null");
+        assertEquals("Malformed request", errorDto.getError(), "Error code should match");
+        assertEquals("Malformed request", errorDto.getDetails(), "Error description should be null for null cause");
+    }
+
+
+}


### PR DESCRIPTION
#### Description
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
Gracefully handled `DecodingException` upon receiving malformed data (specifically dates).

#### List of Changes
<!--- Describe your changes in detail -->
`DecodingExceptions` has been handled by Spring Boot, which returns a `400 BAD REQUEST` HTTP code with a generic DTO; now a custom and more descriptive DTO is returned instead.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This abides by error handling rules already in place.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- Pre-Deploy Test
  - [X] Unit
  - [X] Integration (Narrow)
- Post-Deploy Test
  - [ ] Isolated Microservice
  - [ ] Broader Integration
  - [ ] Acceptance
  - [ ] Performance & Load

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] PATCH - Bug fix (backwards compatible bug fixes)
- [ ] MINOR - New feature (add functionality in a backwards compatible manner)
- [ ] MAJOR - Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
