### PR TITLE
feat: [SRTP-233] handle 429 errors upon saving sent RTP

### DIFF
--- a/src/main/java/it/gov/pagopa/rtp/activator/service/rtp/SendRTPServiceImpl.java
+++ b/src/main/java/it/gov/pagopa/rtp/activator/service/rtp/SendRTPServiceImpl.java
@@ -138,11 +138,11 @@ public class SendRTPServiceImpl implements SendRTPService {
   }
 
   private RetryBackoffSpec sendRetryPolicy() {
-    final var backoff = serviceProviderConfig.send().retry().maxAttempts();
-    final var durationInMillis = serviceProviderConfig.send().retry().backoffMinDuration();
+    final var maxAttempts = serviceProviderConfig.send().retry().maxAttempts();
+    final var minDurationMillis = serviceProviderConfig.send().retry().backoffMinDuration();
     final var jitter = serviceProviderConfig.send().retry().backoffJitter();
 
-    return Retry.backoff(backoff, Duration.ofMillis(durationInMillis))
+    return Retry.backoff(maxAttempts, Duration.ofMillis(minDurationMillis))
         .jitter(jitter)
         .doAfterRetry(signal -> log.info("Retry number {}", signal.totalRetries()));
   }

--- a/src/main/java/it/gov/pagopa/rtp/activator/service/rtp/SendRTPServiceImpl.java
+++ b/src/main/java/it/gov/pagopa/rtp/activator/service/rtp/SendRTPServiceImpl.java
@@ -25,7 +25,10 @@ import it.gov.pagopa.rtp.activator.epcClient.model.OrganisationIdentification29E
 import it.gov.pagopa.rtp.activator.epcClient.model.PersonIdentification13EPC25922V30DS02WrapperDto;
 import it.gov.pagopa.rtp.activator.epcClient.model.SepaRequestToPayRequestResourceDto;
 import java.time.Duration;
+import java.util.Objects;
 import java.util.UUID;
+
+import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.aot.hint.annotation.RegisterReflectionForBinding;
 import org.springframework.stereotype.Service;
@@ -66,33 +69,50 @@ public class SendRTPServiceImpl implements SendRTPService {
     this.objectMapper = new ObjectMapper().enable(SerializationFeature.INDENT_OUTPUT);
   }
 
-  @Override
-  public Mono<Rtp> send(Rtp rtp) {
 
-    return activationApi.findActivationByPayerId(UUID.randomUUID(), rtp.payerId(),
-            serviceProviderConfig.activation().apiVersion())
-        .onErrorMap(WebClientResponseException.class, this::mapActivationResponseToException)
-        .map(act -> act.getPayer().getRtpSpId())
-        .map(rtp::toRtpWithActivationInfo)
-        .flatMap(rtpRepository::save)
-        .flatMap(this::logRtpAsJson)
-        .flatMap(rtpToSend ->
-            // response is ignored atm
-            sendApi.postRequestToPayRequests(UUID.randomUUID(), UUID.randomUUID().toString(),
-                    sepaRequestToPayMapper.toEpcRequestToPay(rtpToSend))
-                .retryWhen(sendRetryPolicy())
-                .onErrorMap(Throwable::getCause)
-                .map(response -> rtpToSend)
-                .defaultIfEmpty(rtpToSend)
-                .doOnSuccess(rtpSent -> log.info("RTP sent to {} with id: {}", rtpSent.serviceProviderDebtor(),
-                    rtpSent.resourceID().getId()))
-        )
-        .map(rtp::toRtpSent)
-        .flatMap(rtpRepository::save)
-        .doOnSuccess(rtpSaved -> log.info("RTP saved with id: {}", rtpSaved.resourceID().getId()))
-        .onErrorMap(WebClientResponseException.class, this::mapExternalSendResponseToException)
-        .switchIfEmpty(Mono.error(new PayerNotActivatedException()));
+  @NonNull
+  @Override
+  public Mono<Rtp> send(@NonNull final Rtp rtp) {
+    Objects.requireNonNull(rtp, "Rtp cannot be null");
+
+    final var activationData = activationApi.findActivationByPayerId(UUID.randomUUID(), rtp.payerId(),
+                    serviceProviderConfig.activation().apiVersion())
+            .onErrorMap(WebClientResponseException.class, this::mapActivationResponseToException);
+
+    final var rtpToSend = activationData.map(act -> act.getPayer().getRtpSpId())
+            .map(rtp::toRtpWithActivationInfo)
+            .flatMap(rtpRepository::save)
+            .flatMap(this::logRtpAsJson);
+
+    final var sentRtp = rtpToSend.flatMap(this::sendRtpInner)
+            .map(rtp::toRtpSent)
+            .flatMap(
+                    rtpToSave -> rtpRepository.save(rtpToSave)
+                            .retryWhen(sendRetryPolicy())
+                            .doOnError(ex -> log.error("Failed after retries", ex))
+
+            );
+
+    return sentRtp.doOnSuccess(rtpSaved -> log.info("RTP saved with id: {}", rtpSaved.resourceID().getId()))
+            .onErrorMap(WebClientResponseException.class, this::mapExternalSendResponseToException)
+            .switchIfEmpty(Mono.error(new PayerNotActivatedException()));
   }
+
+
+  @NonNull
+  private Mono<Rtp> sendRtpInner(@NonNull final Rtp rtpToSend) {
+    Objects.requireNonNull(rtpToSend, "Rtp to send cannot be null.");
+
+    return sendApi.postRequestToPayRequests(UUID.randomUUID(), UUID.randomUUID().toString(),
+                    sepaRequestToPayMapper.toEpcRequestToPay(rtpToSend))
+            .retryWhen(sendRetryPolicy())
+            .onErrorMap(Throwable::getCause)
+            .map(response -> rtpToSend)
+            .defaultIfEmpty(rtpToSend)
+            .doOnSuccess(rtpSent -> log.info("RTP sent to {} with id: {}", rtpSent.serviceProviderDebtor(),
+                    rtpSent.resourceID().getId()));
+  }
+
 
   private Throwable mapActivationResponseToException(WebClientResponseException exception) {
     return switch (exception.getStatusCode()) {
@@ -118,9 +138,12 @@ public class SendRTPServiceImpl implements SendRTPService {
   }
 
   private RetryBackoffSpec sendRetryPolicy() {
-    return Retry.backoff(serviceProviderConfig.send().retry().maxAttempts(),
-            Duration.ofMillis(serviceProviderConfig.send().retry().backoffMinDuration()))
-        .jitter(serviceProviderConfig.send().retry().backoffJitter())
+    final var backoff = serviceProviderConfig.send().retry().maxAttempts();
+    final var durationInMillis = serviceProviderConfig.send().retry().backoffMinDuration();
+    final var jitter = serviceProviderConfig.send().retry().backoffJitter();
+
+    return Retry.backoff(backoff, Duration.ofMillis(durationInMillis))
+        .jitter(jitter)
         .doAfterRetry(signal -> log.info("Retry number {}", signal.totalRetries()));
   }
 

--- a/src/main/java/it/gov/pagopa/rtp/activator/service/rtp/SendRTPServiceImpl.java
+++ b/src/main/java/it/gov/pagopa/rtp/activator/service/rtp/SendRTPServiceImpl.java
@@ -84,7 +84,7 @@ public class SendRTPServiceImpl implements SendRTPService {
             .flatMap(rtpRepository::save)
             .flatMap(this::logRtpAsJson);
 
-    final var sentRtp = rtpToSend.flatMap(this::sendRtpInner)
+    final var sentRtp = rtpToSend.flatMap(this::sendRtpToServiceProviderDebtor)
             .map(rtp::toRtpSent)
             .flatMap(
                     rtpToSave -> rtpRepository.save(rtpToSave)
@@ -100,7 +100,7 @@ public class SendRTPServiceImpl implements SendRTPService {
 
 
   @NonNull
-  private Mono<Rtp> sendRtpInner(@NonNull final Rtp rtpToSend) {
+  private Mono<Rtp> sendRtpToServiceProviderDebtor(@NonNull final Rtp rtpToSend) {
     Objects.requireNonNull(rtpToSend, "Rtp to send cannot be null.");
 
     return sendApi.postRequestToPayRequests(UUID.randomUUID(), UUID.randomUUID().toString(),

--- a/src/test/java/it/gov/pagopa/rtp/activator/service/rtp/SendRTPServiceTest.java
+++ b/src/test/java/it/gov/pagopa/rtp/activator/service/rtp/SendRTPServiceTest.java
@@ -47,7 +47,7 @@ class SendRTPServiceTest {
     private ReadApi readApi;
     private final ServiceProviderConfig serviceProviderConfig = new ServiceProviderConfig(
         new Activation("http://localhost:8080"),
-        new Send("v1", new Retry(3, 1000, 0.75)));
+        new Send("v1", new Retry(3, 100, 0.75)));
     @Mock
     private RtpRepository rtpRepository;
     @Mock
@@ -278,11 +278,6 @@ class SendRTPServiceTest {
     }
 
 
-    private Rtp mockRtp(@NonNull final RtpStatus status) {
-        return mockRtp(status, ResourceID.createNew(), LocalDateTime.now());
-    }
-
-
     private Rtp mockRtp(
             @NonNull final RtpStatus status,
             @NonNull final ResourceID resourceId,
@@ -303,14 +298,16 @@ class SendRTPServiceTest {
 
 
     private ActivationDto mockActivationDto() {
-        var activationRtpSpId = "activationRtpSpId";
-        var activationFiscalCode = "activationFiscalCode";
+        var spId = "activationRtpSpId";
+        var fiscalCode = "activationFiscalCode";
+
+        var payerDto = new PayerDto();
+        payerDto.setRtpSpId(spId);
+        payerDto.setFiscalCode(fiscalCode);
+
         var fakeActivationDto = new ActivationDto();
         fakeActivationDto.setId(UUID.randomUUID());
         fakeActivationDto.setEffectiveActivationDate(LocalDateTime.now());
-        var payerDto = new PayerDto();
-        payerDto.setRtpSpId(activationRtpSpId);
-        payerDto.setFiscalCode(activationFiscalCode);
         fakeActivationDto.setPayer(payerDto);
 
         return fakeActivationDto;


### PR DESCRIPTION
#### Description
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
Implemented retry logic upon saving sent `RTP`.

#### List of Changes
<!--- Describe your changes in detail -->
Added an exponential backoff retry strategy upon saving sent `RTP`:
the params of the strategy (namely `maxAttempts`, `minDurationMillis` and `jitter`) used are the ones already defined for retrying and configurable via properties.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This has been done to make RTP send logic more robust and resilient.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- Pre-Deploy Test
  - [X] Unit
  - [X] Integration (Narrow)
- Post-Deploy Test
  - [ ] Isolated Microservice
  - [ ] Broader Integration
  - [ ] Acceptance
  - [ ] Performance & Load

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] PATCH - Bug fix (backwards compatible bug fixes)
- [X] MINOR - New feature (add functionality in a backwards compatible manner)
- [ ] MAJOR - Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
