### PR TITLE
fix: [SRTP-250] add boid value to scheme name

### DIFF
--- a/src/main/java/it/gov/pagopa/rtp/activator/service/rtp/SepaRequestToPayMapper.java
+++ b/src/main/java/it/gov/pagopa/rtp/activator/service/rtp/SepaRequestToPayMapper.java
@@ -87,8 +87,12 @@ public class SepaRequestToPayMapper {
     if (rtp.serviceProviderDebtor().matches(BIC_REGEX)) {
       dbtFinancialInstitutionIdentification18EPC25922V30DS02Dto.setBICFI(rtp.serviceProviderDebtor());
     } else {
+      var financialIdentificationSchemeName1ChoiceDto = new FinancialIdentificationSchemeName1ChoiceDto();
+      financialIdentificationSchemeName1ChoiceDto.setCd("BOID");
+
       var genericFinancialIdentification1Dto = new GenericFinancialIdentification1Dto();
       genericFinancialIdentification1Dto.setId(rtp.serviceProviderDebtor());
+      genericFinancialIdentification1Dto.setSchmeNm(financialIdentificationSchemeName1ChoiceDto);
       dbtFinancialInstitutionIdentification18EPC25922V30DS02Dto.setOthr(genericFinancialIdentification1Dto);
     }
 

--- a/src/test/java/it/gov/pagopa/rtp/activator/service/rtp/SepaRequestToPayMapperTest.java
+++ b/src/test/java/it/gov/pagopa/rtp/activator/service/rtp/SepaRequestToPayMapperTest.java
@@ -147,6 +147,7 @@ class SepaRequestToPayMapperTest {
     // Verify debtor information
     assertEquals(nRtp.payerName(), pmtInf.getDbtr().getNm());
     assertEquals(nRtp.serviceProviderDebtor(), pmtInf.getDbtrAgt().getFinInstnId().getOthr().getId());
+    assertEquals("BOID", pmtInf.getDbtrAgt().getFinInstnId().getOthr().getSchmeNm().getCd());
 
     // Verify credit transfer transaction
     var cdtTrfTx = pmtInf.getCdtTrfTx().get(0);


### PR DESCRIPTION
#### Description
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR proposes to change the SRTP EPC mapper. The change consists into evaluate the field `pmtInf.getDbtrAgt().getFinInstnId().getOthr().getSchmeNm().getCd()` with the value `BOID`
#### List of Changes
<!--- Describe your changes in detail -->

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- Pre-Deploy Test
  - [x] Unit
  - [x] Integration (Narrow)
- Post-Deploy Test
  - [ ] Isolated Microservice
  - [ ] Broader Integration
  - [ ] Acceptance
  - [ ] Performance & Load

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] PATCH - Bug fix (backwards compatible bug fixes)
- [ ] MINOR - New feature (add functionality in a backwards compatible manner)
- [ ] MAJOR - Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
