### PR TITLE
feat: [SRTP-267] Add blob storage call before sending RTP

### DIFF
--- a/src/main/java/it/gov/pagopa/rtp/activator/configuration/ApplicationConfig.java
+++ b/src/main/java/it/gov/pagopa/rtp/activator/configuration/ApplicationConfig.java
@@ -31,4 +31,5 @@ public class ApplicationConfig {
     httpClient.getApiClient().setBasePath(serviceProviderConfig.send().epcMockUrl());
     return httpClient;
   }
+
 }

--- a/src/main/java/it/gov/pagopa/rtp/activator/service/rtp/SendRTPServiceImpl.java
+++ b/src/main/java/it/gov/pagopa/rtp/activator/service/rtp/SendRTPServiceImpl.java
@@ -42,7 +42,7 @@ import reactor.util.retry.RetryBackoffSpec;
 
 @Service
 @Slf4j
-@RegisterReflectionForBinding({ SepaRequestToPayRequestResourceDto.class,
+@RegisterReflectionForBinding({SepaRequestToPayRequestResourceDto.class,
     PersonIdentification13EPC25922V30DS02WrapperDto.class, ISODateWrapperDto.class,
     ExternalPersonIdentification1CodeEPC25922V30DS02WrapperDto.class,
     ExternalServiceLevel1CodeWrapperDto.class,
@@ -80,8 +80,8 @@ public class SendRTPServiceImpl implements SendRTPService {
     Objects.requireNonNull(rtp, "Rtp cannot be null");
 
     final var activationData = activationApi.findActivationByPayerId(UUID.randomUUID(),
-        rtp.payerId(),
-        serviceProviderConfig.activation().apiVersion())
+            rtp.payerId(),
+            serviceProviderConfig.activation().apiVersion())
         .onErrorMap(WebClientResponseException.class, this::mapActivationResponseToException);
 
     final var rtpToSend = activationData.map(act -> act.getPayer().getRtpSpId())
@@ -99,7 +99,7 @@ public class SendRTPServiceImpl implements SendRTPService {
         );
 
     return sentRtp.doOnSuccess(
-        rtpSaved -> log.info("RTP saved with id: {}", rtpSaved.resourceID().getId()))
+            rtpSaved -> log.info("RTP saved with id: {}", rtpSaved.resourceID().getId()))
         .onErrorMap(WebClientResponseException.class, this::mapExternalSendResponseToException)
         .switchIfEmpty(Mono.error(new PayerNotActivatedException()));
   }
@@ -116,9 +116,9 @@ public class SendRTPServiceImpl implements SendRTPService {
         .flatMap(basePath -> {
           sendApi.setApiClient(sendApi.getApiClient().setBasePath(basePath));
           return sendApi.postRequestToPayRequests(
-              UUID.randomUUID(),
-              UUID.randomUUID().toString(),
-              sepaRequestToPayMapper.toEpcRequestToPay(rtpToSend))
+                  UUID.randomUUID(),
+                  UUID.randomUUID().toString(),
+                  sepaRequestToPayMapper.toEpcRequestToPay(rtpToSend))
               .retryWhen(sendRetryPolicy());
         })
         .onErrorMap(Throwable::getCause)

--- a/src/main/java/it/gov/pagopa/rtp/activator/service/rtp/SendRTPServiceImpl.java
+++ b/src/main/java/it/gov/pagopa/rtp/activator/service/rtp/SendRTPServiceImpl.java
@@ -25,6 +25,7 @@ import it.gov.pagopa.rtp.activator.epcClient.model.OrganisationIdentification29E
 import it.gov.pagopa.rtp.activator.epcClient.model.PersonIdentification13EPC25922V30DS02WrapperDto;
 import it.gov.pagopa.rtp.activator.epcClient.model.SepaRequestToPayRequestResourceDto;
 import java.time.Duration;
+import java.util.HashMap;
 import java.util.Objects;
 import java.util.UUID;
 
@@ -104,6 +105,11 @@ public class SendRTPServiceImpl implements SendRTPService {
   @NonNull
   private Mono<Rtp> sendRtpToServiceProviderDebtor(@NonNull final Rtp rtpToSend) {
     Objects.requireNonNull(rtpToSend, "Rtp to send cannot be null.");
+    
+    // the placeholderhashmap will be change with the cache call
+    HashMap<String,String> placeHolderHashMap = new HashMap<String, String>();
+    placeHolderHashMap.put("UNCRITMM", "https://cbiglobeopenbankingapigateway.nexi.it/srtp/sp/sepa-request-to-pay-requests");
+    sendApi.getApiClient().setBasePath(placeHolderHashMap.get(rtpToSend.serviceProviderCreditor()));
 
     return sendApi.postRequestToPayRequests(UUID.randomUUID(), UUID.randomUUID().toString(),
             sepaRequestToPayMapper.toEpcRequestToPay(rtpToSend))

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -55,6 +55,6 @@ cache:
 blob-storage:
   storage-account-name: ${AZURE_STORAGE_ACCOUNT_NAME:cstardweurtpblobstorage}
   container-name: ${AZURE_STORAGE_CONTAINER_NAME:rtp-debtor-service-provider}
-  blob-name: ${AZURE_BLOB_NAME:testname.json}
+  blob-name: ${AZURE_BLOB_NAME:serviceregistry.json}
   managed-identity: ${IDENTITY_CLIENT_ID:}
 

--- a/src/test/java/it/gov/pagopa/rtp/activator/service/rtp/SendRTPServiceTest.java
+++ b/src/test/java/it/gov/pagopa/rtp/activator/service/rtp/SendRTPServiceTest.java
@@ -12,6 +12,8 @@ import it.gov.pagopa.rtp.activator.configuration.ServiceProviderConfig.Send;
 import it.gov.pagopa.rtp.activator.configuration.ServiceProviderConfig.Send.Retry;
 import it.gov.pagopa.rtp.activator.domain.errors.MessageBadFormed;
 import it.gov.pagopa.rtp.activator.domain.errors.PayerNotActivatedException;
+import it.gov.pagopa.rtp.activator.domain.registryfile.ServiceProviderFullData;
+import it.gov.pagopa.rtp.activator.domain.registryfile.TechnicalServiceProvider;
 import it.gov.pagopa.rtp.activator.domain.rtp.ResourceID;
 import it.gov.pagopa.rtp.activator.domain.rtp.Rtp;
 import it.gov.pagopa.rtp.activator.domain.rtp.RtpRepository;
@@ -19,12 +21,15 @@ import it.gov.pagopa.rtp.activator.domain.rtp.RtpStatus;
 import it.gov.pagopa.rtp.activator.epcClient.api.DefaultApi;
 import it.gov.pagopa.rtp.activator.epcClient.model.SepaRequestToPayRequestResourceDto;
 import it.gov.pagopa.rtp.activator.epcClient.model.SynchronousSepaRequestToPayCreationResponseDto;
+import it.gov.pagopa.rtp.activator.service.registryfile.RegistryDataService;
 
 import java.math.BigDecimal;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -56,6 +61,9 @@ class SendRTPServiceTest {
   @Mock
   private DefaultApi defaultApi;
 
+  @Mock
+  private RegistryDataService registryDataService;
+
   private SendRTPServiceImpl sendRTPService;
 
   final String noticeNumber = "12345";
@@ -78,7 +86,7 @@ class SendRTPServiceTest {
   @BeforeEach
   void setUp() {
     sendRTPService = new SendRTPServiceImpl(sepaRequestToPayMapper, readApi,
-        serviceProviderConfig, rtpRepository, defaultApi);
+        serviceProviderConfig, rtpRepository, defaultApi, registryDataService);
     inputRtp = Rtp.builder().noticeNumber(noticeNumber).amount(amount).description(description)
         .expiryDate(expiryDate)
         .payerId(payerId).payeeName(payeeName).payeeId(payeeId)
@@ -98,6 +106,12 @@ class SendRTPServiceTest {
 
     SepaRequestToPayRequestResourceDto mockSepaRequestToPayRequestResource = new SepaRequestToPayRequestResourceDto()
         .callbackUrl(URI.create("http://callback.url"));
+
+    TechnicalServiceProvider mockTechnicalServiceProvider = new TechnicalServiceProvider("rtpSpId", "name", "endpoint", "certificateSerialNumber", null);
+    ServiceProviderFullData mockedServiceProviderFullData = new ServiceProviderFullData("testId", "testname", mockTechnicalServiceProvider);
+    Map<String,ServiceProviderFullData> mockedData = new HashMap<String, ServiceProviderFullData>();
+    mockedData.put("rtpSpId", mockedServiceProviderFullData);
+    when(registryDataService.getRegistryData()).thenReturn(Mono.just(mockedData));
 
     when(sepaRequestToPayMapper.toEpcRequestToPay(any()))
         .thenReturn(mockSepaRequestToPayRequestResource);
@@ -184,6 +198,11 @@ class SendRTPServiceTest {
     var fakeActivationDto = mockActivationDto();
     var expectedRtp = mockRtp();
 
+    TechnicalServiceProvider mockTechnicalServiceProvider = new TechnicalServiceProvider("rtpSpId", "name", "endpoint", "certificateSerialNumber", null);
+    ServiceProviderFullData mockedServiceProviderFullData = new ServiceProviderFullData("testId", "testname", mockTechnicalServiceProvider);
+    Map<String,ServiceProviderFullData> mockedData = new HashMap<String, ServiceProviderFullData>();
+    mockedData.put("rtpSpId", mockedServiceProviderFullData);
+    when(registryDataService.getRegistryData()).thenReturn(Mono.just(mockedData));
     when(readApi.findActivationByPayerId(any(), any(), any()))
         .thenReturn(Mono.just(fakeActivationDto));
     when(defaultApi.postRequestToPayRequests(any(), any(), any()))

--- a/src/test/java/it/gov/pagopa/rtp/activator/service/rtp/SendRTPServiceTest.java
+++ b/src/test/java/it/gov/pagopa/rtp/activator/service/rtp/SendRTPServiceTest.java
@@ -99,6 +99,58 @@ class SendRTPServiceTest {
   }
 
   @Test
+  void testSend() {
+    var fakeActivationDto = mockActivationDto();
+
+    var expectedRtp = mockRtp();
+
+    SepaRequestToPayRequestResourceDto mockSepaRequestToPayRequestResource = new SepaRequestToPayRequestResourceDto()
+        .callbackUrl(URI.create("http://callback.url"));
+
+    Map<String, ServiceProviderFullData> mockRegistryData = new HashMap<>();
+    mockRegistryData.put(activationRtpSpId, new ServiceProviderFullData("", "",
+        new TechnicalServiceProvider("", "", "http://test-endpoint.com", "", null)));
+
+    var mockApiClient = mock(it.gov.pagopa.rtp.activator.epcClient.invoker.ApiClient.class);
+    when(mockApiClient.setBasePath(any())).thenReturn(mockApiClient);
+    when(defaultApi.getApiClient()).thenReturn(mockApiClient);
+    when(mockApiClient.setBasePath(any())).thenReturn(mockApiClient);
+
+    when(sepaRequestToPayMapper.toEpcRequestToPay(any()))
+        .thenReturn(mockSepaRequestToPayRequestResource);
+    when(readApi.findActivationByPayerId(any(), any(), any()))
+        .thenReturn(Mono.just(fakeActivationDto));
+    when(rtpRepository.save(any()))
+        .thenReturn(Mono.just(expectedRtp));
+    when(registryDataService.getRegistryData())
+        .thenReturn(Mono.just(mockRegistryData));
+    when(defaultApi.postRequestToPayRequests(any(), any(), any()))
+        .thenReturn(Mono.just(new SynchronousSepaRequestToPayCreationResponseDto()));
+
+    Mono<Rtp> result = sendRTPService.send(inputRtp);
+    StepVerifier.create(result)
+        .expectNextMatches(rtp -> rtp.noticeNumber().equals(expectedRtp.noticeNumber())
+            && rtp.amount().equals(expectedRtp.amount())
+            && rtp.description().equals(expectedRtp.description())
+            && rtp.expiryDate().equals(expectedRtp.expiryDate())
+            && rtp.payerId().equals(expectedRtp.payerId())
+            && rtp.payerName().equals(expectedRtp.payerName())
+            && rtp.payeeName().equals(expectedRtp.payeeName())
+            && rtp.payeeId().equals(expectedRtp.payeeId())
+            && rtp.serviceProviderDebtor().equals(expectedRtp.serviceProviderDebtor())
+            && rtp.iban().equals(expectedRtp.iban())
+            && rtp.payTrxRef().equals(expectedRtp.payTrxRef())
+            && rtp.flgConf().equals(expectedRtp.flgConf())
+            && rtp.status().equals(expectedRtp.status())
+            && rtp.subject().equals(expectedRtp.subject()))
+        .verifyComplete();
+    verify(sepaRequestToPayMapper, times(2)).toEpcRequestToPay(any(Rtp.class));
+    verify(readApi, times(1)).findActivationByPayerId(any(), any(), any());
+    verify(defaultApi, times(1)).postRequestToPayRequests(any(), any(), any());
+    verify(rtpRepository, times(2)).save(any());
+  }
+
+  @Test
   void givenPayerIdNotActivatedWhenSendThenMonoError() {
 
     when(readApi.findActivationByPayerId(any(), any(), any()))
@@ -147,30 +199,112 @@ class SendRTPServiceTest {
   }
 
   @Test
-  void givenRtp_whenSavingFailsIndefinitely_thenThrows() {
-    final var sourceRtp = mockRtp();
+  void givenInternalErrorOnExternalSendWhenSendThenPropagateMonoError() {
+    var fakeActivationDto = mockActivationDto();
+    var expectedRtp = mockRtp();
+    // New mock for registry data
+    Map<String, ServiceProviderFullData> mockRegistryData = new HashMap<>();
+    mockRegistryData.put(activationRtpSpId, new ServiceProviderFullData("", "",
+        new TechnicalServiceProvider("", "", "http://test-endpoint.com", "", null)));
 
-    // Mock activation lookup
+    var mockApiClient = mock(it.gov.pagopa.rtp.activator.epcClient.invoker.ApiClient.class);
+    when(mockApiClient.setBasePath(any())).thenReturn(mockApiClient);
+    when(defaultApi.getApiClient()).thenReturn(mockApiClient);
+    when(mockApiClient.setBasePath(any())).thenReturn(mockApiClient);
+
+    when(registryDataService.getRegistryData())
+        .thenReturn(Mono.just(mockRegistryData));
+    when(readApi.findActivationByPayerId(any(), any(), any()))
+        .thenReturn(Mono.just(fakeActivationDto));
+    when(defaultApi.postRequestToPayRequests(any(), any(), any()))
+        .thenReturn(Mono.error(new WebClientResponseException(500, "Internal Server Error", null, null, null)));
+    when(rtpRepository.save(any()))
+        .thenReturn(Mono.just(expectedRtp));
+
+    Mono<Rtp> result = sendRTPService.send(inputRtp);
+
+    StepVerifier.create(result)
+        .expectError(UnsupportedOperationException.class)
+        .verify();
+
+    verify(sepaRequestToPayMapper, times(2)).toEpcRequestToPay(any(Rtp.class));
+    verify(readApi, times(1)).findActivationByPayerId(any(), any(), any());
+    verify(defaultApi, times(1)).postRequestToPayRequests(any(), any(), any());
+    verify(rtpRepository, times(1)).save(any());
+  }
+
+  @Test
+  void givenRtp_whenSavingFailsOnce_thenRetriesAndSucceeds() {
+    final var resourceId = ResourceID.createNew();
+    final var savingDateTime = LocalDateTime.now();
+
+    final var sourceRtp = mockRtp(RtpStatus.CREATED, resourceId, savingDateTime);
+    final var rtpSent = mockRtp(RtpStatus.SENT, resourceId, savingDateTime);
+    // New mock for registry data
+    Map<String, ServiceProviderFullData> mockRegistryData = new HashMap<>();
+    mockRegistryData.put(activationRtpSpId, new ServiceProviderFullData("", "",
+        new TechnicalServiceProvider("", "", "http://test-endpoint.com", "", null)));
+
+    var mockApiClient = mock(it.gov.pagopa.rtp.activator.epcClient.invoker.ApiClient.class);
+    when(mockApiClient.setBasePath(any())).thenReturn(mockApiClient);
+    when(defaultApi.getApiClient()).thenReturn(mockApiClient);
+    when(mockApiClient.setBasePath(any())).thenReturn(mockApiClient);
+
+    when(registryDataService.getRegistryData())
+        .thenReturn(Mono.just(mockRegistryData));
     when(readApi.findActivationByPayerId(any(), any(), any()))
         .thenReturn(Mono.just(mockActivationDto()));
 
-    // Mock SEPA request mapping
-    SepaRequestToPayRequestResourceDto mockSepaRequest = new SepaRequestToPayRequestResourceDto()
-        .callbackUrl(URI.create("http://callback.url"));
-    when(sepaRequestToPayMapper.toEpcRequestToPay(any()))
-        .thenReturn(mockSepaRequest);
+    /*
+     * Mocks the save method.
+     * The first then return is due to a prior invocation of the method that is not
+     * under retry test.
+     * Subsequent returns are actually testing retry logic.
+     */
 
-    // Setup registry data
-    TechnicalServiceProvider mockTsp = new TechnicalServiceProvider(
-        activationRtpSpId, "name", "endpoint", "certificateSerialNumber", null);
-    ServiceProviderFullData mockSpData = new ServiceProviderFullData(
-        activationRtpSpId, "testname", mockTsp);
-    Map<String, ServiceProviderFullData> mockData = new HashMap<>();
-    mockData.put(activationRtpSpId, mockSpData);
+    final var saveAttempts = new AtomicInteger();
+    when(rtpRepository.save(any()))
+        .thenAnswer(invocation -> {
+          if (saveAttempts.getAndIncrement() == 2) {
+            return Mono.error(new RuntimeException("Simulated DB failure"));
+          }
+          return Mono.just(invocation.getArgument(0));
+        });
+
+    when(defaultApi.postRequestToPayRequests(any(), any(), any()))
+        .thenReturn(Mono.empty());
+
+    StepVerifier.create(sendRTPService.send(sourceRtp))
+        .expectNext(rtpSent)
+        .verifyComplete();
+
+    verify(rtpRepository, times(2)).save(any());
+  }
+
+  @Test
+  void givenRtp_whenSavingFailsIndefinitely_thenThrows() {
+    final var sourceRtp = mockRtp();
+
+    when(readApi.findActivationByPayerId(any(), any(), any()))
+        .thenReturn(Mono.just(mockActivationDto()));
+    Map<String, ServiceProviderFullData> mockRegistryData = new HashMap<>();
+    mockRegistryData.put(activationRtpSpId, new ServiceProviderFullData("", "",
+        new TechnicalServiceProvider("", "", "http://test-endpoint.com", "", null)));
+
+    var mockApiClient = mock(it.gov.pagopa.rtp.activator.epcClient.invoker.ApiClient.class);
+    when(mockApiClient.setBasePath(any())).thenReturn(mockApiClient);
+    when(defaultApi.getApiClient()).thenReturn(mockApiClient);
+    when(mockApiClient.setBasePath(any())).thenReturn(mockApiClient);
+
     when(registryDataService.getRegistryData())
-        .thenReturn(Mono.just(mockData));
+        .thenReturn(Mono.just(mockRegistryData));
+    /*
+     * Mocks the save method.
+     * The first then return is due to a prior invocation of the method that is not
+     * under retry test.
+     * Subsequent returns are actually testing retry logic.
+     */
 
-    // Mock repository save with failure after first attempt
     final var firstSaveAttempt = new AtomicBoolean(true);
     when(rtpRepository.save(any()))
         .thenAnswer(invocation -> {
@@ -180,13 +314,14 @@ class SendRTPServiceTest {
           return Mono.error(new RuntimeException("Simulated DB failure"));
         });
 
-    // Execute and verify
+    when(defaultApi.postRequestToPayRequests(any(), any(), any()))
+        .thenReturn(Mono.empty());
+
     StepVerifier.create(sendRTPService.send(sourceRtp))
         .expectError(RuntimeException.class)
         .verify();
 
-    // Verify save was called at least once
-    verify(rtpRepository, atLeastOnce()).save(any());
+    verify(rtpRepository, times(2)).save(any());
   }
 
   private Rtp mockRtp() {

--- a/src/test/java/it/gov/pagopa/rtp/activator/service/rtp/SendRTPServiceTest.java
+++ b/src/test/java/it/gov/pagopa/rtp/activator/service/rtp/SendRTPServiceTest.java
@@ -114,7 +114,6 @@ class SendRTPServiceTest {
     var mockApiClient = mock(it.gov.pagopa.rtp.activator.epcClient.invoker.ApiClient.class);
     when(mockApiClient.setBasePath(any())).thenReturn(mockApiClient);
     when(defaultApi.getApiClient()).thenReturn(mockApiClient);
-    when(mockApiClient.setBasePath(any())).thenReturn(mockApiClient);
 
     when(sepaRequestToPayMapper.toEpcRequestToPay(any()))
         .thenReturn(mockSepaRequestToPayRequestResource);
@@ -210,7 +209,6 @@ class SendRTPServiceTest {
     var mockApiClient = mock(it.gov.pagopa.rtp.activator.epcClient.invoker.ApiClient.class);
     when(mockApiClient.setBasePath(any())).thenReturn(mockApiClient);
     when(defaultApi.getApiClient()).thenReturn(mockApiClient);
-    when(mockApiClient.setBasePath(any())).thenReturn(mockApiClient);
 
     when(registryDataService.getRegistryData())
         .thenReturn(Mono.just(mockRegistryData));
@@ -248,7 +246,6 @@ class SendRTPServiceTest {
     var mockApiClient = mock(it.gov.pagopa.rtp.activator.epcClient.invoker.ApiClient.class);
     when(mockApiClient.setBasePath(any())).thenReturn(mockApiClient);
     when(defaultApi.getApiClient()).thenReturn(mockApiClient);
-    when(mockApiClient.setBasePath(any())).thenReturn(mockApiClient);
 
     when(registryDataService.getRegistryData())
         .thenReturn(Mono.just(mockRegistryData));
@@ -294,7 +291,6 @@ class SendRTPServiceTest {
     var mockApiClient = mock(it.gov.pagopa.rtp.activator.epcClient.invoker.ApiClient.class);
     when(mockApiClient.setBasePath(any())).thenReturn(mockApiClient);
     when(defaultApi.getApiClient()).thenReturn(mockApiClient);
-    when(mockApiClient.setBasePath(any())).thenReturn(mockApiClient);
 
     when(registryDataService.getRegistryData())
         .thenReturn(Mono.just(mockRegistryData));


### PR DESCRIPTION
#### Description
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This pr uses the method previously implemented to get and cache data from blob storage to get the correct uri to use inside the API call to send an RTP to the specific service provide debtor. 

#### List of Changes
<!--- Describe your changes in detail -->

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- Pre-Deploy Test
  - [x] Unit
  - [x] Integration (Narrow)
- Post-Deploy Test
  - [ ] Isolated Microservice
  - [ ] Broader Integration
  - [ ] Acceptance
  - [ ] Performance & Load

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] PATCH - Bug fix (backwards compatible bug fixes)
- [ ] MINOR - New feature (add functionality in a backwards compatible manner)
- [ ] MAJOR - Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
