### PR TITLE
fix: [SRTP-352] config client http timeout

### DIFF
--- a/src/main/java/it/gov/pagopa/rtp/activator/configuration/ServiceProviderConfig.java
+++ b/src/main/java/it/gov/pagopa/rtp/activator/configuration/ServiceProviderConfig.java
@@ -15,7 +15,8 @@ public record ServiceProviderConfig(
 
   public record Send(
       String epcMockUrl,
-      Retry retry
+      Retry retry,
+      Long timeout
   ) {
 
     public record Retry(

--- a/src/main/java/it/gov/pagopa/rtp/activator/configuration/mtlswebclient/DefaultMtlsWebClientFactory.java
+++ b/src/main/java/it/gov/pagopa/rtp/activator/configuration/mtlswebclient/DefaultMtlsWebClientFactory.java
@@ -1,5 +1,7 @@
 package it.gov.pagopa.rtp.activator.configuration.mtlswebclient;
 
+import it.gov.pagopa.rtp.activator.configuration.ServiceProviderConfig;
+import java.time.Duration;
 import org.springframework.http.client.reactive.ReactorClientHttpConnector;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -10,15 +12,19 @@ import reactor.netty.http.client.HttpClient;
 @Component
 public class DefaultMtlsWebClientFactory implements MtlsWebClientFactory {
   private final SslContextFactory sslContextFactory;
+  private final ServiceProviderConfig serviceProviderConfig;
 
-  public DefaultMtlsWebClientFactory(SslContextFactory sslContextFactory) {
+  public DefaultMtlsWebClientFactory(SslContextFactory sslContextFactory,
+      ServiceProviderConfig serviceProviderConfig) {
     this.sslContextFactory = sslContextFactory;
+    this.serviceProviderConfig = serviceProviderConfig;
   }
 
   @Override
   public WebClient createMtlsWebClient() {
     HttpClient httpClient = HttpClient.create()
-        .secure(sslContextSpec -> sslContextSpec.sslContext(sslContextFactory.getSslContext()));
+        .secure(sslContextSpec -> sslContextSpec.sslContext(sslContextFactory.getSslContext()))
+        .responseTimeout(Duration.ofMillis(serviceProviderConfig.send().timeout()));
 
     return WebClient.builder().clientConnector(new ReactorClientHttpConnector(httpClient)).build();
   }

--- a/src/main/java/it/gov/pagopa/rtp/activator/controller/rtp/RtpExceptionHandler.java
+++ b/src/main/java/it/gov/pagopa/rtp/activator/controller/rtp/RtpExceptionHandler.java
@@ -104,6 +104,11 @@ public class RtpExceptionHandler {
     return ResponseEntity.badRequest().body(errorsDto);
   }
 
+  /**
+   * Handles {@link ReadTimeoutException} exceptions thrown during the processing of requests.
+   * @param ex the {@link ReadTimeoutException} thrown during request processing.
+   * @return a {@link ResponseEntity} with status {@code 504 Gateway Timeout}.
+   */
   @ExceptionHandler(ReadTimeoutException.class)
   @ResponseStatus(HttpStatus.GATEWAY_TIMEOUT)
   public ResponseEntity<Void> handleReadTimeoutException(ReadTimeoutException ex) {

--- a/src/main/java/it/gov/pagopa/rtp/activator/controller/rtp/RtpExceptionHandler.java
+++ b/src/main/java/it/gov/pagopa/rtp/activator/controller/rtp/RtpExceptionHandler.java
@@ -1,5 +1,6 @@
 package it.gov.pagopa.rtp.activator.controller.rtp;
 
+import io.netty.handler.timeout.ReadTimeoutException;
 import it.gov.pagopa.rtp.activator.domain.errors.MessageBadFormed;
 import it.gov.pagopa.rtp.activator.model.generated.send.MalformedRequestErrorResponseDto;
 import java.util.Collection;
@@ -103,4 +104,9 @@ public class RtpExceptionHandler {
     return ResponseEntity.badRequest().body(errorsDto);
   }
 
+  @ExceptionHandler(ReadTimeoutException.class)
+  @ResponseStatus(HttpStatus.GATEWAY_TIMEOUT)
+  public ResponseEntity<Void> handleReadTimeoutException(ReadTimeoutException ex) {
+    return ResponseEntity.status(HttpStatus.GATEWAY_TIMEOUT).build();
+  }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -34,6 +34,7 @@ service-provider:
     api-version: v1
   send:
     epc-mock-url: ${EPC_MOCK_URL:https://api-rtp.dev.cstar.pagopa.it/rtp/mock}
+    timeout: ${EPC_SEND_TIMEOUT_MS:10000}
     retry:
       max-attempts: ${EPC_SEND_RETRY_MAX_ATTEMPTS:3}
       backoff-min-duration: ${EPC_SEND_RETRY_BACKOFF_MIN_DURATION_MS:1000}

--- a/src/main/terraform/env/cstar-d-weu-rtp/terraform.tfvars
+++ b/src/main/terraform/env/cstar-d-weu-rtp/terraform.tfvars
@@ -59,7 +59,7 @@ rtp_environment_configs = {
   EPC_SEND_RETRY_MAX_ATTEMPTS             : 1
   EPC_SEND_RETRY_BACKOFF_MIN_DURATION_MS  : 1000
   EPC_SEND_RETRY_BACKOFF_JITTER           : 0.75
-  EPC_SEND_TIMEOUT_MS                     : 10000
+  EPC_SEND_TIMEOUT_MS                     : 6000
   AZURE_STORAGE_ACCOUNT_NAME              : "cstardweurtpblobstorage"
   AZURE_STORAGE_CONTAINER_NAME            : "rtp-debtor-service-provider"
   AZURE_BLOB_NAME                         : "serviceregistry.json"

--- a/src/main/terraform/env/cstar-d-weu-rtp/terraform.tfvars
+++ b/src/main/terraform/env/cstar-d-weu-rtp/terraform.tfvars
@@ -59,6 +59,7 @@ rtp_environment_configs = {
   EPC_SEND_RETRY_MAX_ATTEMPTS             : 1
   EPC_SEND_RETRY_BACKOFF_MIN_DURATION_MS  : 1000
   EPC_SEND_RETRY_BACKOFF_JITTER           : 0.75
+  EPC_SEND_TIMEOUT_MS                     : 10000
   AZURE_STORAGE_ACCOUNT_NAME              : "cstardweurtpblobstorage"
   AZURE_STORAGE_CONTAINER_NAME            : "rtp-debtor-service-provider"
   AZURE_BLOB_NAME                         : "serviceregistry.json"

--- a/src/main/terraform/env/cstar-p-weu-rtp/terraform.tfvars
+++ b/src/main/terraform/env/cstar-p-weu-rtp/terraform.tfvars
@@ -57,7 +57,7 @@ rtp_environment_configs = {
   EPC_SEND_RETRY_MAX_ATTEMPTS             : 1
   EPC_SEND_RETRY_BACKOFF_MIN_DURATION_MS  : 1000
   EPC_SEND_RETRY_BACKOFF_JITTER           : 0.75
-  EPC_SEND_TIMEOUT_MS                     : 10000
+  EPC_SEND_TIMEOUT_MS                     : 6000
   AZURE_STORAGE_ACCOUNT_NAME              : "cstarpweurtpblobstorage"
   AZURE_STORAGE_CONTAINER_NAME            : "rtp-debtor-service-provider"
   AZURE_BLOB_NAME                         : "serviceregistry.json"

--- a/src/main/terraform/env/cstar-p-weu-rtp/terraform.tfvars
+++ b/src/main/terraform/env/cstar-p-weu-rtp/terraform.tfvars
@@ -57,6 +57,7 @@ rtp_environment_configs = {
   EPC_SEND_RETRY_MAX_ATTEMPTS             : 1
   EPC_SEND_RETRY_BACKOFF_MIN_DURATION_MS  : 1000
   EPC_SEND_RETRY_BACKOFF_JITTER           : 0.75
+  EPC_SEND_TIMEOUT_MS                     : 10000
   AZURE_STORAGE_ACCOUNT_NAME              : "cstarpweurtpblobstorage"
   AZURE_STORAGE_CONTAINER_NAME            : "rtp-debtor-service-provider"
   AZURE_BLOB_NAME                         : "serviceregistry.json"

--- a/src/main/terraform/env/cstar-u-weu-rtp/terraform.tfvars
+++ b/src/main/terraform/env/cstar-u-weu-rtp/terraform.tfvars
@@ -59,6 +59,7 @@ rtp_environment_configs = {
   EPC_SEND_RETRY_MAX_ATTEMPTS             : 1
   EPC_SEND_RETRY_BACKOFF_MIN_DURATION_MS  : 1000
   EPC_SEND_RETRY_BACKOFF_JITTER           : 0.75
+  EPC_SEND_TIMEOUT_MS                     : 10000
   AZURE_STORAGE_ACCOUNT_NAME              : "cstaruweurtpblobstorage"
   AZURE_STORAGE_CONTAINER_NAME            : "rtp-debtor-service-provider"
   AZURE_BLOB_NAME                         : "serviceregistry.json"

--- a/src/main/terraform/env/cstar-u-weu-rtp/terraform.tfvars
+++ b/src/main/terraform/env/cstar-u-weu-rtp/terraform.tfvars
@@ -59,7 +59,7 @@ rtp_environment_configs = {
   EPC_SEND_RETRY_MAX_ATTEMPTS             : 1
   EPC_SEND_RETRY_BACKOFF_MIN_DURATION_MS  : 1000
   EPC_SEND_RETRY_BACKOFF_JITTER           : 0.75
-  EPC_SEND_TIMEOUT_MS                     : 10000
+  EPC_SEND_TIMEOUT_MS                     : 6000
   AZURE_STORAGE_ACCOUNT_NAME              : "cstaruweurtpblobstorage"
   AZURE_STORAGE_CONTAINER_NAME            : "rtp-debtor-service-provider"
   AZURE_BLOB_NAME                         : "serviceregistry.json"

--- a/src/test/java/it/gov/pagopa/rtp/activator/configuration/mtlswebclient/DefaultMtlsWebClientFactoryTest.java
+++ b/src/test/java/it/gov/pagopa/rtp/activator/configuration/mtlswebclient/DefaultMtlsWebClientFactoryTest.java
@@ -1,5 +1,6 @@
 package it.gov.pagopa.rtp.activator.configuration.mtlswebclient;
 
+import it.gov.pagopa.rtp.activator.configuration.ServiceProviderConfig;
 import it.gov.pagopa.rtp.activator.configuration.ssl.SslContextFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -20,6 +21,8 @@ class DefaultMtlsWebClientFactoryTest {
 
    @Mock
    private SslContextFactory sslContextFactory;
+   @Mock
+   private ServiceProviderConfig config;
 
    @Mock
    private SslContext sslContext;
@@ -28,12 +31,13 @@ class DefaultMtlsWebClientFactoryTest {
 
    @BeforeEach
    void setUp() {
-       mtlsWebClientFactory = new DefaultMtlsWebClientFactory(sslContextFactory);
+       mtlsWebClientFactory = new DefaultMtlsWebClientFactory(sslContextFactory, config);
    }
 
    @Test
    void createMtlsWebClient_CreatesWebClientWithSslContext() {
        when(sslContextFactory.getSslContext()).thenReturn(sslContext);
+       when(config.send().timeout()).thenReturn(10000L);
 
        WebClient result = mtlsWebClientFactory.createMtlsWebClient();
 

--- a/src/test/java/it/gov/pagopa/rtp/activator/configuration/mtlswebclient/DefaultMtlsWebClientFactoryTest.java
+++ b/src/test/java/it/gov/pagopa/rtp/activator/configuration/mtlswebclient/DefaultMtlsWebClientFactoryTest.java
@@ -1,47 +1,46 @@
 package it.gov.pagopa.rtp.activator.configuration.mtlswebclient;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.netty.handler.ssl.SslContext;
 import it.gov.pagopa.rtp.activator.configuration.ServiceProviderConfig;
+import it.gov.pagopa.rtp.activator.configuration.ServiceProviderConfig.Send;
 import it.gov.pagopa.rtp.activator.configuration.ssl.SslContextFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-
 import org.springframework.web.reactive.function.client.WebClient;
-
-import io.netty.handler.ssl.SslContext;
-
-
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class DefaultMtlsWebClientFactoryTest {
 
-   @Mock
-   private SslContextFactory sslContextFactory;
-   @Mock
-   private ServiceProviderConfig config;
+  @Mock
+  private SslContextFactory sslContextFactory;
+  @Mock
+  private ServiceProviderConfig config;
 
-   @Mock
-   private SslContext sslContext;
+  @Mock
+  private SslContext sslContext;
 
-   private DefaultMtlsWebClientFactory mtlsWebClientFactory;
+  private DefaultMtlsWebClientFactory mtlsWebClientFactory;
 
-   @BeforeEach
-   void setUp() {
-       mtlsWebClientFactory = new DefaultMtlsWebClientFactory(sslContextFactory, config);
-   }
+  @BeforeEach
+  void setUp() {
+    mtlsWebClientFactory = new DefaultMtlsWebClientFactory(sslContextFactory, config);
+  }
 
-   @Test
-   void createMtlsWebClient_CreatesWebClientWithSslContext() {
-       when(sslContextFactory.getSslContext()).thenReturn(sslContext);
-       when(config.send().timeout()).thenReturn(10000L);
+  @Test
+  void createMtlsWebClient_CreatesWebClientWithSslContext() {
+    when(sslContextFactory.getSslContext()).thenReturn(sslContext);
+    when(config.send()).thenReturn(new Send(null, null, 10000L));
 
-       WebClient result = mtlsWebClientFactory.createMtlsWebClient();
+    WebClient result = mtlsWebClientFactory.createMtlsWebClient();
 
-       assertNotNull(result);
-       verify(sslContextFactory).getSslContext();
-   }
+    assertNotNull(result);
+    verify(sslContextFactory).getSslContext();
+  }
 }

--- a/src/test/java/it/gov/pagopa/rtp/activator/controller/rtp/RtpExceptionHandlerTest.java
+++ b/src/test/java/it/gov/pagopa/rtp/activator/controller/rtp/RtpExceptionHandlerTest.java
@@ -1,5 +1,12 @@
 package it.gov.pagopa.rtp.activator.controller.rtp;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.netty.handler.timeout.ReadTimeoutException;
 import it.gov.pagopa.rtp.activator.model.generated.send.MalformedRequestErrorResponseDto;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -11,10 +18,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.support.WebExchangeBindException;
-
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 class RtpExceptionHandlerTest {
 
@@ -110,5 +113,18 @@ class RtpExceptionHandlerTest {
         assertNull(response.getBody());
     }
 
+    @Test
+    void givenReadTimeoutException_whenHandled_thenReturnsGatewayTimeout() {
+        // Given
+        ReadTimeoutException readTimeoutException = ReadTimeoutException.INSTANCE;
+
+        // When
+        ResponseEntity<Void> response = rtpExceptionHandler.handleReadTimeoutException(readTimeoutException);
+
+        // Then
+        assertNotNull(response, "Response should not be null");
+        assertEquals(HttpStatus.GATEWAY_TIMEOUT, response.getStatusCode(), "Status should be 504 Gateway Timeout");
+        assertNull(response.getBody(), "Response body should be null");
+    }
 
 }

--- a/src/test/java/it/gov/pagopa/rtp/activator/service/rtp/SendRTPServiceTest.java
+++ b/src/test/java/it/gov/pagopa/rtp/activator/service/rtp/SendRTPServiceTest.java
@@ -62,7 +62,7 @@ class SendRTPServiceTest {
   private final ServiceProviderConfig serviceProviderConfig = new ServiceProviderConfig(
       "http://localhost:8080",
       new Activation("http://localhost:8080"),
-      new Send("v1", new Retry(3, 100, 0.75)));
+      new Send("v1", new Retry(3, 100, 0.75), 10000L));
   @Mock
   private RtpRepository rtpRepository;
   @Mock

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -12,6 +12,7 @@ service-provider:
     api-version: v1
   send:
     epc-mock-url: ${EPC_MOCK_URL:http://localhost:8080/rtp/mock}
+    timeout: ${EPC_SEND_TIMEOUT_MS:10000}
     retry:
       max-attempts: ${EPC_SEND_RETRY_MAX_ATTEMPTS:3}
       backoff-min-duration: ${EPC_SEND_RETRY_BACKOFF_MIN_DURATION_MS:1000}


### PR DESCRIPTION
#### Description
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR proposes to add the response timeout http client configuration.
The timeout is set on 6 seconds and there will be 2 retries within a single send request.
#### List of Changes
<!--- Describe your changes in detail -->

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- Pre-Deploy Test
  - [x] Unit
  - [x] Integration (Narrow)
- Post-Deploy Test
  - [ ] Isolated Microservice
  - [ ] Broader Integration
  - [ ] Acceptance
  - [ ] Performance & Load

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] PATCH - Bug fix (backwards compatible bug fixes)
- [ ] MINOR - New feature (add functionality in a backwards compatible manner)
- [ ] MAJOR - Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
