### PR TITLE
fix: [SRTP-371] fix field length InstrId and messageID

### DIFF
--- a/src/main/java/it/gov/pagopa/rtp/activator/service/rtp/SepaRequestToPayMapper.java
+++ b/src/main/java/it/gov/pagopa/rtp/activator/service/rtp/SepaRequestToPayMapper.java
@@ -65,7 +65,7 @@ public class SepaRequestToPayMapper {
     partyIdentification135EPC25922V30DS02Dto.setNm("PagoPA");// FIXED
 
     var groupHeader105EPC25922V30DS02Dto = new GroupHeader105EPC25922V30DS02Dto()
-        .msgId(rtp.resourceID().getId().toString())
+        .msgId(rtp.resourceID().getId().toString().replace("-",""))
         .creDtTm(rtp.savingDateTime().toString())
         .nbOfTxs("1")// FIXED
         .initgPty(partyIdentification135EPC25922V30DS02Dto);
@@ -110,7 +110,7 @@ public class SepaRequestToPayMapper {
         .finInstnId(dbtFinancialInstitutionIdentification18EPC25922V30DS02Dto);
 
     var paymentIdentification6EPC25922V30DS02Dto = new PaymentIdentification6EPC25922V30DS02Dto()
-        .instrId(rtp.resourceID().getId().toString())
+        .instrId(rtp.resourceID().getId().toString().replace("-",""))
         .endToEndId(rtp.noticeNumber());
 
     var serviceLevel8ChoiceDto = new ServiceLevel8ChoiceDto()

--- a/src/test/java/it/gov/pagopa/rtp/activator/service/rtp/SepaRequestToPayMapperTest.java
+++ b/src/test/java/it/gov/pagopa/rtp/activator/service/rtp/SepaRequestToPayMapperTest.java
@@ -66,7 +66,7 @@ class SepaRequestToPayMapperTest {
     assertNotNull(result);
     assertEquals(resourceId.getId().toString(), result.getResourceId());
     assertEquals(this.callbackProperties.url().send(), result.getCallbackUrl().toString());
-    assertEquals(resourceId.getId().toString(),
+    assertEquals(resourceId.getId().toString().replace("-",""),
         result.getDocument().getCdtrPmtActvtnReq().getGrpHdr().getMsgId());
     assertTrue(result.getDocument().getCdtrPmtActvtnReq().getPmtInf().get(0).getCdtTrfTx().get(0)
         .getRmtInf()
@@ -74,7 +74,7 @@ class SepaRequestToPayMapperTest {
 
     // Verify group header
     var grpHdr = result.getDocument().getCdtrPmtActvtnReq().getGrpHdr();
-    assertEquals(nRtp.resourceID().getId().toString(), grpHdr.getMsgId());
+    assertEquals(nRtp.resourceID().getId().toString().replace("-",""), grpHdr.getMsgId());
     assertEquals(nRtp.savingDateTime().toString(), grpHdr.getCreDtTm());
 
     // Verify payment information
@@ -146,7 +146,7 @@ class SepaRequestToPayMapperTest {
     assertNotNull(result);
     assertEquals(resourceId.getId().toString(), result.getResourceId());
     assertEquals(this.callbackProperties.url().send(), result.getCallbackUrl().toString());
-    assertEquals(resourceId.getId().toString(),
+    assertEquals(resourceId.getId().toString().replace("-",""),
         result.getDocument().getCdtrPmtActvtnReq().getGrpHdr().getMsgId());
     assertTrue(result.getDocument().getCdtrPmtActvtnReq().getPmtInf().get(0).getCdtTrfTx().get(0)
         .getRmtInf()
@@ -154,7 +154,7 @@ class SepaRequestToPayMapperTest {
 
     // Verify group header
     var grpHdr = result.getDocument().getCdtrPmtActvtnReq().getGrpHdr();
-    assertEquals(nRtp.resourceID().getId().toString(), grpHdr.getMsgId());
+    assertEquals(nRtp.resourceID().getId().toString().replace("-",""), grpHdr.getMsgId());
     assertEquals(nRtp.savingDateTime().toString(), grpHdr.getCreDtTm());
 
     // Verify payment information


### PR DESCRIPTION
#### Description
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
The fields inside the SRTP message were 36 characters long, while the standard specifies a length of 1 to 35 characters.

#### List of Changes
<!--- Describe your changes in detail -->
I've shortened the length of the fields in SepaRequestToPayMapper by removing the dashes from the ID. 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This fix resolves the issue with the length of the InstrId and messageID fields.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- Pre-Deploy Test
  - [x] Unit
  - [ ] Integration (Narrow)
- Post-Deploy Test
  - [ ] Isolated Microservice
  - [ ] Broader Integration
  - [ ] Acceptance
  - [ ] Performance & Load

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] PATCH - Bug fix (backwards compatible bug fixes)
- [ ] MINOR - New feature (add functionality in a backwards compatible manner)
- [ ] MAJOR - Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
