### PR TITLE
fix: [SRTP-398] Correct date formatting for effectiveActivation field

### DIFF
--- a/src/main/java/it/gov/pagopa/rtp/activator/configuration/ApplicationConfig.java
+++ b/src/main/java/it/gov/pagopa/rtp/activator/configuration/ApplicationConfig.java
@@ -22,6 +22,7 @@ public class ApplicationConfig {
     return JsonMapper.builder()
         .enable(SerializationFeature.INDENT_OUTPUT)
         .addModule(new JavaTimeModule())
+        .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
         .build();
   }
 


### PR DESCRIPTION
#### Description
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR fixes the serialization of effectiveActivationDate, which was previously returned as an array of date components. Now it’s serialized as a standard ISO 8601 timestamp string.

#### List of Changes
<!--- Describe your changes in detail -->
- Disabled WRITE_DATES_AS_TIMESTAMPS

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The current format ([2025, 4, 3, 10, 49, 1, 120000000]) is not standard and hard to consume. This change improves readability and client compatibility.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- Pre-Deploy Test
  - [ ] Unit
  - [x] Integration (Narrow)
- Post-Deploy Test
  - [x] Isolated Microservice
  - [ ] Broader Integration
  - [ ] Acceptance
  - [ ] Performance & Load

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] PATCH - Bug fix (backwards compatible bug fixes)
- [ ] MINOR - New feature (add functionality in a backwards compatible manner)
- [ ] MAJOR - Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
