### PR TITLE
feat: [SRTP-134] simplify activation by removing find and handling DuplicateKeyException on save

### DIFF
--- a/src/main/java/it/gov/pagopa/rtp/activator/repository/activation/ActivationEntity.java
+++ b/src/main/java/it/gov/pagopa/rtp/activator/repository/activation/ActivationEntity.java
@@ -4,7 +4,6 @@ import java.time.Instant;
 import java.util.UUID;
 
 import org.springframework.data.annotation.Id;
-import org.springframework.data.mongodb.core.index.Indexed;
 import org.springframework.data.mongodb.core.mapping.Document;
 
 import lombok.AllArgsConstructor;
@@ -22,6 +21,5 @@ public class ActivationEntity {
     private UUID id;
     private String serviceProviderDebtor;
     private Instant effectiveActivationDate;
-    @Indexed(unique = true)
     private String fiscalCode;
 }

--- a/src/main/java/it/gov/pagopa/rtp/activator/repository/activation/ActivationEntity.java
+++ b/src/main/java/it/gov/pagopa/rtp/activator/repository/activation/ActivationEntity.java
@@ -4,6 +4,7 @@ import java.time.Instant;
 import java.util.UUID;
 
 import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.index.Indexed;
 import org.springframework.data.mongodb.core.mapping.Document;
 
 import lombok.AllArgsConstructor;
@@ -21,6 +22,6 @@ public class ActivationEntity {
     private UUID id;
     private String serviceProviderDebtor;
     private Instant effectiveActivationDate;
-
+    @Indexed(unique = true)
     private String fiscalCode;
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -9,7 +9,6 @@ spring:
       uri: ${COSMOS_ACCOUNT_RTP_CONNECTION_STRING:mongodb://localhost:27017}
       database: ${DB_NAME:rtp}
       uuid-representation: standard
-      auto-index-creation: true
   cloud:
     azure:
       monitor:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -9,7 +9,7 @@ spring:
       uri: ${COSMOS_ACCOUNT_RTP_CONNECTION_STRING:mongodb://localhost:27017}
       database: ${DB_NAME:rtp}
       uuid-representation: standard
-
+      auto-index-creation: true
   cloud:
     azure:
       monitor:

--- a/src/test/java/it/gov/pagopa/rtp/activator/service/activation/ActivationPayerServiceImplTest.java
+++ b/src/test/java/it/gov/pagopa/rtp/activator/service/activation/ActivationPayerServiceImplTest.java
@@ -11,6 +11,7 @@ import it.gov.pagopa.rtp.activator.domain.errors.PayerAlreadyExists;
 import it.gov.pagopa.rtp.activator.domain.payer.Payer;
 import it.gov.pagopa.rtp.activator.domain.payer.ActivationID;
 import it.gov.pagopa.rtp.activator.repository.activation.ActivationDBRepository;
+import org.springframework.dao.DuplicateKeyException;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
@@ -23,81 +24,75 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class ActivationPayerServiceImplTest {
 
-    @Mock
-    private ActivationDBRepository activationDBRepository;
+  @Mock private ActivationDBRepository activationDBRepository;
 
-    @InjectMocks
-    private ActivationPayerServiceImpl activationPayerService;
+  @InjectMocks private ActivationPayerServiceImpl activationPayerService;
 
-    private Payer payer;
-    private ActivationID activationID;
-    private String rtpSpId;
-    private String fiscalCode;
+  private Payer payer;
+  private ActivationID activationID;
+  private String rtpSpId;
+  private String fiscalCode;
 
-    @BeforeEach
-    void setUp() {
-        rtpSpId = "testRtpSpId";
-        fiscalCode = "TSTFSC12A34B567C";
+  @BeforeEach
+  void setUp() {
+    rtpSpId = "testRtpSpId";
+    fiscalCode = "TSTFSC12A34B567C";
 
-        activationID = ActivationID.createNew();
-        payer = new Payer(activationID, rtpSpId, fiscalCode, Instant.now());
-    }
+    activationID = ActivationID.createNew();
+    payer = new Payer(activationID, rtpSpId, fiscalCode, Instant.now());
+  }
 
-    @Test
-    void testActivatePayerSuccessful() {
+  @Test
+  void testActivatePayerSuccessful() {
 
-        when(activationDBRepository.findByFiscalCode(fiscalCode)).thenReturn(Mono.empty());
-        when(activationDBRepository.save(any(Payer.class)))
-                .thenAnswer(invocation -> Mono.just(invocation.getArgument(0)));
+    when(activationDBRepository.save(any(Payer.class)))
+        .thenAnswer(invocation -> Mono.just(invocation.getArgument(0)));
 
-        StepVerifier.create(activationPayerService.activatePayer(rtpSpId, fiscalCode)).expectNextMatches(pay    -> {
-            // Verify payer details
-            assert pay.serviceProviderDebtor().equals(rtpSpId);
-            assert pay.fiscalCode().equals(fiscalCode);
-            assert pay.activationID() != null;
-            assert pay.effectiveActivationDate() != null;
-            return true;
+    StepVerifier.create(activationPayerService.activatePayer(rtpSpId, fiscalCode))
+        .expectNextMatches(pay -> {
+              // Verify payer details
+              assert pay.serviceProviderDebtor().equals(rtpSpId);
+              assert pay.fiscalCode().equals(fiscalCode);
+              assert pay.activationID() != null;
+              assert pay.effectiveActivationDate() != null;
+              return true;
         })
-                .verifyComplete();
+        .verifyComplete();
 
-        verify(activationDBRepository).findByFiscalCode(fiscalCode);
-        verify(activationDBRepository).save(any(Payer.class));
-    }
+    verify(activationDBRepository).save(any(Payer.class));
+  }
 
-    @Test
-    void testActivatePayerAlreadyExists() {
+  @Test
+  void testActivatePayerAlreadyExists() {
 
-        when(activationDBRepository.findByFiscalCode(fiscalCode)).thenReturn(Mono.just(payer));
+    when(activationDBRepository.save(any(Payer.class)))
+        .thenReturn(Mono.error(new DuplicateKeyException("duplicate")));
 
-        StepVerifier.create(activationPayerService.activatePayer(rtpSpId, fiscalCode))
-                .expectError(PayerAlreadyExists.class)
-                .verify();
+    StepVerifier.create(activationPayerService.activatePayer(rtpSpId, fiscalCode))
+        .expectError(PayerAlreadyExists.class)
+        .verify();
+  }
 
-        verify(activationDBRepository).findByFiscalCode(fiscalCode);
-    }
+  @Test
+  void testFindPayerSuccessful() {
+    when(activationDBRepository.findByFiscalCode(fiscalCode)).thenReturn(Mono.just(payer));
 
-    @Test
-    void testFindPayerSuccessful() {
-        when(activationDBRepository.findByFiscalCode(fiscalCode)).thenReturn(Mono.just(payer));
+    StepVerifier.create(activationPayerService.findPayer(fiscalCode))
+        .expectNextMatches(pay -> pay.equals(payer))
+        .verifyComplete();
 
-        StepVerifier.create(activationPayerService.findPayer(fiscalCode))
-                .expectNextMatches(pay -> pay.equals(payer)).verifyComplete();
+    verify(activationDBRepository).findByFiscalCode(fiscalCode);
+  }
 
-        verify(activationDBRepository).findByFiscalCode(fiscalCode);
+  @Test
+  void testFindPayerNotFound() {
 
-    }
+    String notExFiscalCode = "nonExistentPayerId";
 
-    @Test
-    void testFindPayerNotFound() {
+    when(activationDBRepository.findByFiscalCode(notExFiscalCode)).thenReturn(Mono.empty());
 
-        String notExFiscalCode = "nonExistentPayerId";
+    StepVerifier.create(activationPayerService.findPayer(notExFiscalCode)).verifyComplete();
 
-        when(activationDBRepository.findByFiscalCode(notExFiscalCode))
-            .thenReturn(Mono.empty());
-
-        StepVerifier.create(activationPayerService.findPayer(notExFiscalCode))
-            .verifyComplete();
-
-        verify(activationDBRepository).findByFiscalCode(notExFiscalCode);
-    }
+    verify(activationDBRepository).findByFiscalCode(notExFiscalCode);
+  }
 }


### PR DESCRIPTION
#### Description
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR refactors the activation logic to remove the preliminary find check before saving a new activation record. Instead, it relies solely on the save operation. If the operation fails with a specific database error code (11000), it maps this to a 409 Conflict HTTP response to indicate that the record already exists.

#### List of Changes
<!--- Describe your changes in detail -->
- Remove the pre-check using findByFiscalCode.
- Use save directly to persist the entity.
- Handle DuplicateKeyException (error code 11000) by mapping it to a PayerAlreadyExists exception.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Previously, the system performed a lookup using findByFiscalCode before attempting to save a new payer record. By handling uniqueness directly through database constraints and exception mapping, we streamline the logic and reduce DB queries.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- Pre-Deploy Test
  - [x] Unit
  - [x] Integration (Narrow)
- Post-Deploy Test
  - [x] Isolated Microservice
  - [ ] Broader Integration
  - [ ] Acceptance
  - [ ] Performance & Load

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] PATCH - Bug fix (backwards compatible bug fixes)
- [x] MINOR - New feature (add functionality in a backwards compatible manner)
- [ ] MAJOR - Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
