### PR TITLE
feat: [SRTP-498] add RTP status persistence in send flow

### DIFF
--- a/src/main/java/it/gov/pagopa/rtp/activator/domain/rtp/Rtp.java
+++ b/src/main/java/it/gov/pagopa/rtp/activator/domain/rtp/Rtp.java
@@ -5,7 +5,6 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.stream.Stream;
 import lombok.Builder;
 import lombok.With;
 
@@ -45,39 +44,6 @@ public record Rtp(String noticeNumber, BigDecimal amount, String description, Lo
                 .triggerEvent(RtpEvent.CREATE_RTP)
                 .build()
         ))
-        .build();
-  }
-
-  public Rtp toRtpSent(Rtp rtp) {
-    final var updatedEvents = Stream.concat(
-        rtp.events().stream(), Stream.of(
-            Event.builder()
-                .timestamp(Instant.now())
-                .precStatus(rtp.status)
-                .triggerEvent(RtpEvent.SEND_RTP)
-                .build()
-        ))
-        .toList();
-
-    return Rtp.builder()
-        .serviceProviderDebtor(rtp.serviceProviderDebtor())
-        .iban(rtp.iban())
-        .payTrxRef(rtp.payTrxRef())
-        .flgConf(rtp.flgConf())
-        .payerName(this.payerName())
-        .payerId(rtp.payerId())
-        .payeeName(rtp.payeeName())
-        .payeeId(rtp.payeeId())
-        .noticeNumber(rtp.noticeNumber())
-        .amount(rtp.amount())
-        .description(rtp.description())
-        .expiryDate(rtp.expiryDate())
-        .resourceID(rtp.resourceID())
-        .subject(this.subject())
-        .serviceProviderCreditor(this.serviceProviderCreditor())
-        .savingDateTime(rtp.savingDateTime())
-        .status(RtpStatus.SENT)
-        .events(updatedEvents)
         .build();
   }
 }

--- a/src/main/java/it/gov/pagopa/rtp/activator/service/rtp/handler/SendRtpHandler.java
+++ b/src/main/java/it/gov/pagopa/rtp/activator/service/rtp/handler/SendRtpHandler.java
@@ -70,8 +70,9 @@ public class SendRtpHandler extends EpcApiInvokerHandler implements RequestHandl
               .doFirst(() -> log.info("Sending RTP to {}", rtpToSend.serviceProviderDebtor()))
               .retryWhen(sendRetryPolicy());
         })
-        .doOnSuccess(resp -> log.info("Mapping sent RTP to {}", TransactionStatus.ACTC))
         .map(resp -> request.withResponse(TransactionStatus.ACTC))
+        .doOnNext(resp -> log.info("Mapping sent RTP to {}", TransactionStatus.ACTC))
+        .switchIfEmpty(Mono.just(request))
         .onErrorResume(IllegalStateException.class, ex -> this.handleRetryError(ex, request))
         .doOnNext(resp -> log.info("Response: {}", resp.response()));
   }

--- a/src/main/java/it/gov/pagopa/rtp/activator/service/rtp/handler/SendRtpProcessorImpl.java
+++ b/src/main/java/it/gov/pagopa/rtp/activator/service/rtp/handler/SendRtpProcessorImpl.java
@@ -27,6 +27,7 @@ public class SendRtpProcessorImpl implements SendRtpProcessor {
   private final Oauth2Handler oauth2Handler;
   private final SendRtpHandler sendRtpHandler;
   private final CancelRtpHandler cancelRtpHandler;
+  private final SendRtpResponseHandler sendRtpResponseHandler;
 
 
   /**
@@ -36,18 +37,21 @@ public class SendRtpProcessorImpl implements SendRtpProcessor {
    * @param oauth2Handler The handler responsible for OAuth2 authentication.
    * @param sendRtpHandler The handler responsible for sending the RTP request.
    * @param cancelRtpHandler The handler responsible for sending the RTP cancellation request.
+   * @param sendRtpResponseHandler The handler responsible for handling the RTP response.
    * @throws NullPointerException if any of the provided handlers are {@code null}.
    */
   public SendRtpProcessorImpl(
       @NonNull final RegistryDataHandler registryDataHandler,
       @NonNull final Oauth2Handler oauth2Handler,
       @NonNull final SendRtpHandler sendRtpHandler,
-      @NonNull final CancelRtpHandler cancelRtpHandler) {
+      @NonNull final CancelRtpHandler cancelRtpHandler,
+      @NonNull final SendRtpResponseHandler sendRtpResponseHandler) {
 
     this.registryDataHandler = Objects.requireNonNull(registryDataHandler);
     this.oauth2Handler = Objects.requireNonNull(oauth2Handler);
     this.sendRtpHandler = Objects.requireNonNull(sendRtpHandler);
     this.cancelRtpHandler = Objects.requireNonNull(cancelRtpHandler);
+    this.sendRtpResponseHandler = Objects.requireNonNull(sendRtpResponseHandler);
   }
 
 
@@ -76,6 +80,8 @@ public class SendRtpProcessorImpl implements SendRtpProcessor {
         .flatMap(this::handleIntermediateSteps)
         .doOnNext(epcRequest -> log.debug("Calling send RTP handler."))
         .flatMap(this.sendRtpHandler::handle)
+        .doOnNext(epcRequest -> log.debug("Handling send RTP response."))
+        .flatMap(this.sendRtpResponseHandler::handle)
         .onErrorMap(ExceptionUtils::gracefullyHandleError)
         .map(EpcRequest::rtpToSend)
         .defaultIfEmpty(rtpToSend)

--- a/src/main/java/it/gov/pagopa/rtp/activator/service/rtp/handler/SendRtpResponseHandler.java
+++ b/src/main/java/it/gov/pagopa/rtp/activator/service/rtp/handler/SendRtpResponseHandler.java
@@ -11,6 +11,10 @@ import org.springframework.stereotype.Component;
 import reactor.core.publisher.Mono;
 
 
+/**
+ * The `SendRtpResponseHandler` class is a component responsible for handling the response of an EPC request.
+ * It updates the RTP status based on the {@link TransactionStatus} received in the response.
+ */
 @Component("sendRtpResponseHandler")
 @Slf4j
 public class SendRtpResponseHandler implements RequestHandler<EpcRequest> {
@@ -18,12 +22,24 @@ public class SendRtpResponseHandler implements RequestHandler<EpcRequest> {
   private final RtpStatusUpdater rtpStatusUpdater;
 
 
-  public SendRtpResponseHandler(
-      @NonNull final RtpStatusUpdater rtpStatusUpdater) {
+  /**
+   * Constructs a new {@link SendRtpResponseHandler} instance with the provided {@link RtpStatusUpdater}.
+   *
+   * @param rtpStatusUpdater the {@link RtpStatusUpdater} instance to be used for updating the RTP status
+   * @throws NullPointerException if `rtpStatusUpdater` is `null`
+   */
+  public SendRtpResponseHandler(@NonNull final RtpStatusUpdater rtpStatusUpdater) {
     this.rtpStatusUpdater = Objects.requireNonNull(rtpStatusUpdater);
   }
 
 
+  /**
+   * Handles the provided {@link EpcRequest} by updating the RTP status based on the transaction status in the response.
+   *
+   * @param request the {@link EpcRequest} to be handled
+   * @return a {@code Mono<EpcRequest>} containing the updated {@link EpcRequest}
+   * @throws NullPointerException if `request` is `null`
+   */
   @Override
   @NonNull
   public Mono<EpcRequest> handle(@NonNull final EpcRequest request) {
@@ -43,11 +59,18 @@ public class SendRtpResponseHandler implements RequestHandler<EpcRequest> {
   }
 
 
+  /**
+   * Triggers the appropriate {@code RTP} status update based on the provided transaction status.
+   *
+   * @param rtpToUpdate the {@link Rtp} instance to be updated
+   * @param transactionStatus the {@link TransactionStatus} to be used for the update
+   * @return a {@code Mono<Rtp>} containing the updated {@link Rtp} instance
+   * @throws NullPointerException if {@code rtpToUpdate} or {@code transactionStatus} is {@code null}
+   */
   @NonNull
   private Mono<Rtp> triggerRtpStatus(
       @NonNull final Rtp rtpToUpdate,
       @NonNull final TransactionStatus transactionStatus) {
-
     return switch (transactionStatus) {
       case ACTC -> this.rtpStatusUpdater.triggerAcceptRtp(rtpToUpdate);
       case ACCP -> Mono.error(new IllegalStateException("Not implemented"));
@@ -55,5 +78,5 @@ public class SendRtpResponseHandler implements RequestHandler<EpcRequest> {
       case ERROR -> this.rtpStatusUpdater.triggerErrorSendRtp(rtpToUpdate);
     };
   }
-
 }
+

--- a/src/main/java/it/gov/pagopa/rtp/activator/service/rtp/handler/SendRtpResponseHandler.java
+++ b/src/main/java/it/gov/pagopa/rtp/activator/service/rtp/handler/SendRtpResponseHandler.java
@@ -41,6 +41,6 @@ public class SendRtpResponseHandler implements RequestHandler<EpcRequest> {
             case ERROR -> this.rtpStatusUpdater.triggerErrorSendRtp(rtpToUpdate);
           };
         })
-        .map(rtp -> request.withRtpToSend(rtp));
+        .map(request::withRtpToSend);
   }
 }

--- a/src/main/java/it/gov/pagopa/rtp/activator/service/rtp/handler/SendRtpResponseHandler.java
+++ b/src/main/java/it/gov/pagopa/rtp/activator/service/rtp/handler/SendRtpResponseHandler.java
@@ -1,0 +1,46 @@
+package it.gov.pagopa.rtp.activator.service.rtp.handler;
+
+import it.gov.pagopa.rtp.activator.service.rtp.RtpStatusUpdater;
+import java.util.Objects;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.lang.NonNull;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+@Component("sendRtpResponseHandler")
+@Slf4j
+public class SendRtpResponseHandler implements RequestHandler<EpcRequest> {
+
+  private final RtpStatusUpdater rtpStatusUpdater;
+
+
+  public SendRtpResponseHandler(
+      @NonNull final RtpStatusUpdater rtpStatusUpdater) {
+    this.rtpStatusUpdater = Objects.requireNonNull(rtpStatusUpdater);
+  }
+
+
+  @Override
+  @NonNull
+  public Mono<EpcRequest> handle(@NonNull final EpcRequest request) {
+    Objects.requireNonNull(request, "request must not be null");
+
+    return Mono.just(request)
+        .doFirst(() -> log.info("Parsing SRTP response"))
+        .flatMap(req -> {
+          final var rtpToUpdate = req.rtpToSend();
+          final var transactionStatus = req.response();
+
+          if (transactionStatus == null)
+            return this.rtpStatusUpdater.triggerSendRtp(rtpToUpdate);
+
+          return switch (transactionStatus) {
+            case ACTC -> this.rtpStatusUpdater.triggerAcceptRtp(rtpToUpdate);
+            case ACCP -> Mono.error(new IllegalStateException("Not implemented"));
+            case RJCT -> this.rtpStatusUpdater.triggerRejectRtp(rtpToUpdate);
+            case ERROR -> this.rtpStatusUpdater.triggerErrorSendRtp(rtpToUpdate);
+          };
+        })
+        .map(rtp -> request.withRtpToSend(rtp));
+  }
+}

--- a/src/main/java/it/gov/pagopa/rtp/activator/service/rtp/handler/SendRtpResponseHandler.java
+++ b/src/main/java/it/gov/pagopa/rtp/activator/service/rtp/handler/SendRtpResponseHandler.java
@@ -38,7 +38,7 @@ public class SendRtpResponseHandler implements RequestHandler<EpcRequest> {
    *
    * @param request the {@link EpcRequest} to be handled
    * @return a {@code Mono<EpcRequest>} containing the updated {@link EpcRequest}
-   * @throws NullPointerException if `request` is `null`
+   * @throws NullPointerException if {@code request} is {@code null}
    */
   @Override
   @NonNull

--- a/src/main/java/it/gov/pagopa/rtp/activator/statemachine/RtpStateMachine.java
+++ b/src/main/java/it/gov/pagopa/rtp/activator/statemachine/RtpStateMachine.java
@@ -1,10 +1,13 @@
 package it.gov.pagopa.rtp.activator.statemachine;
 
+import it.gov.pagopa.rtp.activator.domain.rtp.Event;
 import it.gov.pagopa.rtp.activator.domain.rtp.RtpEvent;
 import it.gov.pagopa.rtp.activator.domain.rtp.RtpStatus;
 import it.gov.pagopa.rtp.activator.repository.rtp.RtpEntity;
+import java.time.Instant;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.Stream;
 import org.reactivestreams.Publisher;
 import org.springframework.lang.NonNull;
 import reactor.core.publisher.Mono;
@@ -87,7 +90,8 @@ public class RtpStateMachine implements StateMachine<RtpEntity, RtpEvent> {
                 String.format("Cannot transition from %s to %s", source, event)))))
         .doOnNext(transition -> transition.getPreTransactionActions()
             .forEach(action -> action.accept(source)))
-        .doOnNext(transition -> source.setStatus(transition.getDestination()))
+        .doOnNext(transition -> this.advanceStatus(
+            source, transition.getDestination(), transition.getEvent()))
         .doOnNext(transition -> transition.getPostTransactionActions()
             .forEach(action -> action.accept(source)))
         .map(transition -> source);
@@ -109,6 +113,39 @@ public class RtpStateMachine implements StateMachine<RtpEntity, RtpEvent> {
     return Optional.of(transitionKey)
         .flatMap(this.transitionConfiguration::getTransition)
         .isPresent();
+  }
+
+
+  /**
+   * Advances the status of the given {@link RtpEntity} to a new status and updates its events.
+   *
+   * @param rtpEntity   the entity whose status is to be updated
+   * @param newStatus   the new status to set for the entity
+   * @param triggerEvent the event that triggered the status change
+   * @throws NullPointerException if any of the arguments is {@code null}
+   */
+  @NonNull
+  private void advanceStatus(
+      @NonNull final RtpEntity rtpEntity,
+      @NonNull final RtpStatus newStatus,
+      @NonNull final RtpEvent triggerEvent) {
+
+    Objects.requireNonNull(rtpEntity, "Entity cannot be null");
+    Objects.requireNonNull(newStatus, "Status cannot be null");
+    Objects.requireNonNull(triggerEvent, "Event cannot be null");
+
+    final var updatedEvents = Stream.concat(
+            rtpEntity.getEvents().stream(), Stream.of(
+                Event.builder()
+                    .timestamp(Instant.now())
+                    .precStatus(rtpEntity.getStatus())
+                    .triggerEvent(triggerEvent)
+                    .build()
+            ))
+        .toList();
+
+    rtpEntity.setStatus(newStatus);
+    rtpEntity.setEvents(updatedEvents);
   }
 }
 

--- a/src/main/java/it/gov/pagopa/rtp/activator/statemachine/RtpStateMachine.java
+++ b/src/main/java/it/gov/pagopa/rtp/activator/statemachine/RtpStateMachine.java
@@ -132,7 +132,7 @@ public class RtpStateMachine implements StateMachine<RtpEntity, RtpEvent> {
 
     Objects.requireNonNull(rtpEntity, "Entity cannot be null");
     Objects.requireNonNull(newStatus, "Status cannot be null");
-    Objects.requireNonNull(triggerEvent, "Event cannot be null");
+    Objects.requireNonNull(triggerEvent, "Trigger event cannot be null");
 
     final var updatedEvents = Stream.concat(
             rtpEntity.getEvents().stream(), Stream.of(

--- a/src/test/java/it/gov/pagopa/rtp/activator/service/rtp/SendRTPServiceTest.java
+++ b/src/test/java/it/gov/pagopa/rtp/activator/service/rtp/SendRTPServiceTest.java
@@ -228,7 +228,7 @@ class SendRTPServiceTest {
         .thenReturn(Mono.just(mockActivationDto()));
 
     when(sendRtpProcessor.sendRtpToServiceProviderDebtor(any()))
-        .thenReturn(Mono.just(sourceRtp));
+        .thenReturn(Mono.just(rtpSent));
 
     /*
      * Mocks the save method.

--- a/src/test/java/it/gov/pagopa/rtp/activator/service/rtp/handler/SendRtpProcessorImplTest.java
+++ b/src/test/java/it/gov/pagopa/rtp/activator/service/rtp/handler/SendRtpProcessorImplTest.java
@@ -34,6 +34,9 @@ class SendRtpProcessorImplTest {
   @Mock
   private CancelRtpHandler cancelRtpHandler;
 
+  @Mock
+  private SendRtpResponseHandler sendRtpResponseHandler;
+
   @InjectMocks
   private SendRtpProcessorImpl sendRtpProcessor;
 
@@ -61,6 +64,8 @@ class SendRtpProcessorImplTest {
     when(oauth2Handler.handle(epcRequestWithRegistryData))
         .thenReturn(Mono.just(epcRequestWithToken));
     when(sendRtpHandler.handle(epcRequestWithToken))
+        .thenReturn(Mono.just(epcRequestWithResponse));
+    when(sendRtpResponseHandler.handle(epcRequestWithResponse))
         .thenReturn(Mono.just(epcRequestWithResponse));
 
     final var resultMono = sendRtpProcessor.sendRtpToServiceProviderDebtor(rtpToSend);

--- a/src/test/java/it/gov/pagopa/rtp/activator/service/rtp/handler/SendRtpResponseHandlerTest.java
+++ b/src/test/java/it/gov/pagopa/rtp/activator/service/rtp/handler/SendRtpResponseHandlerTest.java
@@ -1,10 +1,7 @@
 package it.gov.pagopa.rtp.activator.service.rtp.handler;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
@@ -69,27 +66,6 @@ class SendRtpResponseHandlerTest {
         Arguments.of(TransactionStatus.ERROR, "triggerErrorSendRtp"),
         Arguments.of(null, "triggerSendRtp")
     );
-  }
-
-
-  @Test
-  void givenValidRequest_whenTransactionStatusIsAccp_thenThrowIllegalStateException() {
-    final var request = mock(EpcRequest.class);
-    Rtp rtpToSend = mock(Rtp.class);
-    TransactionStatus transactionStatus = TransactionStatus.ACCP;
-
-    when(request.rtpToSend()).thenReturn(rtpToSend);
-    when(request.response()).thenReturn(transactionStatus);
-
-    // Act
-    Mono<EpcRequest> result = sendRtpResponseHandler.handle(request);
-
-    // Assert
-    StepVerifier.create(result)
-        .expectErrorMatches(throwable -> throwable instanceof IllegalStateException)
-        .verify();
-
-    verify(rtpStatusUpdater, never()).triggerSendRtp(any(Rtp.class));
   }
 
   @ParameterizedTest

--- a/src/test/java/it/gov/pagopa/rtp/activator/service/rtp/handler/SendRtpResponseHandlerTest.java
+++ b/src/test/java/it/gov/pagopa/rtp/activator/service/rtp/handler/SendRtpResponseHandlerTest.java
@@ -34,14 +34,14 @@ class SendRtpResponseHandlerTest {
 
 
   @BeforeEach
-  public void setUp() {
+  void setUp() {
     MockitoAnnotations.openMocks(this);
   }
 
 
   @ParameterizedTest
   @MethodSource("provideTransactionStatusAndExpectedMethodForSuccess")
-  public void givenValidRequest_whenTransactionStatusIsX_thenTriggerY(
+  void givenValidRequest_whenTransactionStatusIsX_thenTriggerY(
       TransactionStatus transactionStatus,
       String expectedMethod)
       throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
@@ -73,7 +73,7 @@ class SendRtpResponseHandlerTest {
 
 
   @Test
-  public void givenValidRequest_whenTransactionStatusIsAccp_thenThrowIllegalStateException() {
+  void givenValidRequest_whenTransactionStatusIsAccp_thenThrowIllegalStateException() {
     final var request = mock(EpcRequest.class);
     Rtp rtpToSend = mock(Rtp.class);
     TransactionStatus transactionStatus = TransactionStatus.ACCP;
@@ -94,7 +94,7 @@ class SendRtpResponseHandlerTest {
 
   @ParameterizedTest
   @MethodSource("provideTransactionStatusForException")
-  public void givenValidRequest_whenTransactionStatusIsX_thenThrowException(
+  void givenValidRequest_whenTransactionStatusIsX_thenThrowException(
       TransactionStatus transactionStatus,
       Class<? extends Throwable> expectedException) {
 
@@ -120,7 +120,7 @@ class SendRtpResponseHandlerTest {
   }
 
   @Test
-  public void givenNullRequest_whenHandleCalled_thenThrowNullPointerException() {
+  void givenNullRequest_whenHandleCalled_thenThrowNullPointerException() {
     assertThrows(NullPointerException.class, () -> sendRtpResponseHandler.handle(null));
   }
 

--- a/src/test/java/it/gov/pagopa/rtp/activator/service/rtp/handler/SendRtpResponseHandlerTest.java
+++ b/src/test/java/it/gov/pagopa/rtp/activator/service/rtp/handler/SendRtpResponseHandlerTest.java
@@ -1,0 +1,127 @@
+package it.gov.pagopa.rtp.activator.service.rtp.handler;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import it.gov.pagopa.rtp.activator.domain.rtp.Rtp;
+import it.gov.pagopa.rtp.activator.domain.rtp.TransactionStatus;
+import it.gov.pagopa.rtp.activator.service.rtp.RtpStatusUpdater;
+import java.lang.reflect.InvocationTargetException;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+class SendRtpResponseHandlerTest {
+
+  @Mock
+  private RtpStatusUpdater rtpStatusUpdater;
+
+  @InjectMocks
+  private SendRtpResponseHandler sendRtpResponseHandler;
+
+
+  @BeforeEach
+  public void setUp() {
+    MockitoAnnotations.openMocks(this);
+  }
+
+
+  @ParameterizedTest
+  @MethodSource("provideTransactionStatusAndExpectedMethodForSuccess")
+  public void givenValidRequest_whenTransactionStatusIsX_thenTriggerY(
+      TransactionStatus transactionStatus,
+      String expectedMethod)
+      throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+
+    final var rtpToSend = mock(Rtp.class);
+    final var request = new EpcRequest(rtpToSend, null, null, transactionStatus);
+
+    when(
+        rtpStatusUpdater.getClass()
+        .getMethod(expectedMethod, Rtp.class)
+        .invoke(rtpStatusUpdater, rtpToSend))
+        .thenReturn(Mono.just(rtpToSend));
+
+    final var result = sendRtpResponseHandler.handle(request);
+
+    StepVerifier.create(result)
+        .expectNextMatches(req -> req.rtpToSend().equals(rtpToSend))
+        .verifyComplete();
+  }
+
+  private static Stream<Arguments> provideTransactionStatusAndExpectedMethodForSuccess() {
+    return Stream.of(
+        Arguments.of(TransactionStatus.ACTC, "triggerAcceptRtp"),
+        Arguments.of(TransactionStatus.RJCT, "triggerRejectRtp"),
+        Arguments.of(TransactionStatus.ERROR, "triggerErrorSendRtp"),
+        Arguments.of(null, "triggerSendRtp")
+    );
+  }
+
+
+  @Test
+  public void givenValidRequest_whenTransactionStatusIsAccp_thenThrowIllegalStateException() {
+    final var request = mock(EpcRequest.class);
+    Rtp rtpToSend = mock(Rtp.class);
+    TransactionStatus transactionStatus = TransactionStatus.ACCP;
+
+    when(request.rtpToSend()).thenReturn(rtpToSend);
+    when(request.response()).thenReturn(transactionStatus);
+
+    // Act
+    Mono<EpcRequest> result = sendRtpResponseHandler.handle(request);
+
+    // Assert
+    StepVerifier.create(result)
+        .expectErrorMatches(throwable -> throwable instanceof IllegalStateException)
+        .verify();
+
+    verify(rtpStatusUpdater, never()).triggerSendRtp(any(Rtp.class));
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideTransactionStatusForException")
+  public void givenValidRequest_whenTransactionStatusIsX_thenThrowException(
+      TransactionStatus transactionStatus,
+      Class<? extends Throwable> expectedException) {
+
+    final var rtpToSend = mock(Rtp.class);
+    EpcRequest request = mock(EpcRequest.class);
+
+    when(request.rtpToSend()).thenReturn(rtpToSend);
+    when(request.response()).thenReturn(transactionStatus);
+
+    final var result = sendRtpResponseHandler.handle(request);
+
+    StepVerifier.create(result)
+        .expectErrorMatches(throwable -> throwable.getClass().equals(expectedException))
+        .verify();
+
+    verifyNoInteractions(rtpStatusUpdater);
+  }
+
+  private static Stream<Arguments> provideTransactionStatusForException() {
+    return Stream.of(
+        Arguments.of(TransactionStatus.ACCP, IllegalStateException.class)
+    );
+  }
+
+  @Test
+  public void givenNullRequest_whenHandleCalled_thenThrowNullPointerException() {
+    assertThrows(NullPointerException.class, () -> sendRtpResponseHandler.handle(null));
+  }
+
+}


### PR DESCRIPTION
#### Description
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR proposes to persist `RtpStatus` change after sending the `SRTP` to the Service Provider of Debtor: it does so in the newly created `SendRtpResponseHandler`, where it parses the given `TransactionStatus` and, based on that, triggers the corresponding transition from `RtpStatusUpdater`.

#### List of Changes
<!--- Describe your changes in detail -->
- Created `SendRtpResponseHandler` to perform the `RtpStatus` update;
- hooked up the above in `SendRtpProcessorImpl::sendRtpToServiceProviderDebtor`.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This allows the service to update the `RtpStatus` based on the `TransactionStatus` returned by the Service Provider of Debtor API.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- Pre-Deploy Test
  - [X] Unit
  - [X] Integration (Narrow)
- Post-Deploy Test
  - [x] Isolated Microservice
  - [ ] Broader Integration
  - [ ] Acceptance
  - [ ] Performance & Load

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] PATCH - Bug fix (backwards compatible bug fixes)
- [X] MINOR - New feature (add functionality in a backwards compatible manner)
- [ ] MAJOR - Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
