### PR TITLE
fix: [SRTP-423] added milliseconds to date format

### DIFF
--- a/src/main/java/it/gov/pagopa/rtp/activator/utils/DateUtils.java
+++ b/src/main/java/it/gov/pagopa/rtp/activator/utils/DateUtils.java
@@ -3,6 +3,7 @@ package it.gov.pagopa.rtp.activator.utils;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
 import java.util.Optional;
 
 public class DateUtils {
@@ -10,7 +11,7 @@ public class DateUtils {
   public static String localDateTimeToOffsetFormat(LocalDateTime localDateTime) {
     return Optional.ofNullable(localDateTime)
         .map(ldt -> ldt.atZone(ZoneId.of("Europe/Rome")))
-        .map(zdt -> zdt.withNano(0))
+        .map(ldt -> ldt.truncatedTo(ChronoUnit.MILLIS))
         .map(DateTimeFormatter.ISO_OFFSET_DATE_TIME::format)
         .orElseThrow(
             () -> new IllegalArgumentException("Couldn't convert local datetime to offset format"));

--- a/src/test/java/it/gov/pagopa/rtp/activator/utils/DateUtilsTest.java
+++ b/src/test/java/it/gov/pagopa/rtp/activator/utils/DateUtilsTest.java
@@ -6,6 +6,7 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.regex.Pattern;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -22,18 +23,17 @@ class DateUtilsTest {
     }
 
     @Test
-    void givenLocalDateTimeWithNanos_whenConvertedToOffsetFormat_thenTruncatesNanoseconds() {
+    void givenLocalDateTimeWithNanos_whenConvertedToOffsetFormat_thenTruncatesToMilliseconds() {
         LocalDateTime localDateTime = LocalDateTime.of(2023, 3, 25, 10, 15, 30, 999_999_999);
         String result = DateUtils.localDateTimeToOffsetFormat(localDateTime);
-        assertTrue(result.endsWith("+01:00") || result.endsWith("+02:00")); // Depends on DST
-        assertFalse(result.contains(".")); // No fractional seconds
+        assertTrue(result.endsWith("+01:00") || result.endsWith("+02:00"));
+        String regex = ".*T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?([+-]\\d{2}:\\d{2})";
+        assertTrue(Pattern.matches(regex, result), "Result has more than milliseconds precision: " + result);
     }
 
     @Test
     void givenNullLocalDateTime_whenConvertedToOffsetFormat_thenThrowsIllegalArgumentException() {
-        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
-            DateUtils.localDateTimeToOffsetFormat(null);
-        });
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> DateUtils.localDateTimeToOffsetFormat(null));
         assertEquals("Couldn't convert local datetime to offset format", exception.getMessage());
     }
 


### PR DESCRIPTION
#### Description
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR updates the formatting of LocalDateTime values to include millisecond precision, instead of truncating at whole seconds.

#### List of Changes
<!--- Describe your changes in detail -->
- Truncate LocalDateTime to milliseconds before formatting

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Previously, timestamps were truncated at seconds, losing sub-second detail. This change ensures consistent millisecond precision for better accuracy and integration with systems expecting fractional seconds.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- Pre-Deploy Test
  - [x] Unit
  - [x] Integration (Narrow)
- Post-Deploy Test
  - [x] Isolated Microservice
  - [ ] Broader Integration
  - [ ] Acceptance
  - [ ] Performance & Load

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] PATCH - Bug fix (backwards compatible bug fixes)
- [ ] MINOR - New feature (add functionality in a backwards compatible manner)
- [ ] MAJOR - Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
