### PR TITLE
feat: [SRTP-422] Handle callback and persist received transaction status in RTP flow

### DIFF
--- a/src/main/java/it/gov/pagopa/rtp/activator/configuration/StateMachineConfiguration.java
+++ b/src/main/java/it/gov/pagopa/rtp/activator/configuration/StateMachineConfiguration.java
@@ -65,6 +65,7 @@ public class StateMachineConfiguration {
         // Transitions from SENT
         .register(new RtpTransitionKey(RtpStatus.SENT, RtpEvent.ACCEPT_RTP), RtpStatus.ACCEPTED, persistRtp())
         .register(new RtpTransitionKey(RtpStatus.SENT, RtpEvent.REJECT_RTP), RtpStatus.REJECTED, persistRtp())
+        .register(new RtpTransitionKey(RtpStatus.SENT, RtpEvent.ERROR_SEND_RTP), RtpStatus.ERROR_SEND, persistRtp())
         .register(new RtpTransitionKey(RtpStatus.SENT, RtpEvent.USER_ACCEPT_RTP), RtpStatus.USER_ACCEPTED, persistRtp())
         .register(new RtpTransitionKey(RtpStatus.SENT, RtpEvent.USER_REJECT_RTP), RtpStatus.USER_REJECTED, persistRtp())
         .register(new RtpTransitionKey(RtpStatus.SENT, RtpEvent.PAY_RTP), RtpStatus.PAYED, persistRtp())

--- a/src/main/java/it/gov/pagopa/rtp/activator/controller/callback/RequestToPayUpdateController.java
+++ b/src/main/java/it/gov/pagopa/rtp/activator/controller/callback/RequestToPayUpdateController.java
@@ -38,8 +38,8 @@ public class RequestToPayUpdateController implements RequestToPayUpdateApi {
 
     return requestBody
         .switchIfEmpty(Mono.error(new IllegalArgumentException("Request body cannot be empty")))
-        .flatMap(s -> certificateChecker.verifyRequestCertificate(s, clientCertificateSerialNumber))
         .flatMap(callbackHandler::handle)
+        .flatMap(s -> certificateChecker.verifyRequestCertificate(s, clientCertificateSerialNumber))
         .doOnNext(PayloadInfoExtractor::populateMdc)
         .<ResponseEntity<Void>>map(s -> ResponseEntity.ok().build())
         .doOnSuccess(resp -> log.info("Send callback processed successfully"))

--- a/src/main/java/it/gov/pagopa/rtp/activator/controller/callback/RequestToPayUpdateController.java
+++ b/src/main/java/it/gov/pagopa/rtp/activator/controller/callback/RequestToPayUpdateController.java
@@ -38,8 +38,11 @@ public class RequestToPayUpdateController implements RequestToPayUpdateApi {
 
     return requestBody
         .switchIfEmpty(Mono.error(new IllegalArgumentException("Request body cannot be empty")))
+        .doOnNext(body -> log.info("Received callback request"))
         .flatMap(callbackHandler::handle)
+        .doOnSuccess(r -> log.info("CallbackHandler completed successfully"))
         .flatMap(s -> certificateChecker.verifyRequestCertificate(s, clientCertificateSerialNumber))
+        .doOnSuccess(r -> log.info("Certificate verification successful"))
         .doOnNext(PayloadInfoExtractor::populateMdc)
         .<ResponseEntity<Void>>map(s -> ResponseEntity.ok().build())
         .doOnSuccess(resp -> log.info("Send callback processed successfully"))

--- a/src/main/java/it/gov/pagopa/rtp/activator/domain/rtp/TransactionStatus.java
+++ b/src/main/java/it/gov/pagopa/rtp/activator/domain/rtp/TransactionStatus.java
@@ -5,6 +5,9 @@ import org.springframework.lang.NonNull;
 import java.util.Arrays;
 import java.util.Optional;
 
+/**
+ * Enumeration of possible transaction statuses for Request-To-Pay (RTP) flows.
+ */
 public enum TransactionStatus {
 
   ACTC("ACTC"),
@@ -21,6 +24,15 @@ public enum TransactionStatus {
     this.value = value;
   }
 
+  /**
+   * Maps a string to the corresponding {@link TransactionStatus} enum value.
+   *
+   * <p>This method is case-sensitive and expects an exact match with the internal value.
+   *
+   * @param text the string to convert (must not be null)
+   * @return the matching {@link TransactionStatus}
+   * @throws IllegalArgumentException if the input is null or no match is found
+   */
   @NonNull
   public static TransactionStatus fromString(final String text) {
     return Arrays.stream(TransactionStatus.values())

--- a/src/main/java/it/gov/pagopa/rtp/activator/domain/rtp/TransactionStatus.java
+++ b/src/main/java/it/gov/pagopa/rtp/activator/domain/rtp/TransactionStatus.java
@@ -3,6 +3,7 @@ package it.gov.pagopa.rtp.activator.domain.rtp;
 import org.springframework.lang.NonNull;
 
 import java.util.Arrays;
+import java.util.Optional;
 
 public enum TransactionStatus {
 
@@ -23,7 +24,9 @@ public enum TransactionStatus {
   @NonNull
   public static TransactionStatus fromString(final String text) {
     return Arrays.stream(TransactionStatus.values())
-            .filter(b -> b.value.equals(text))
+            .filter(b -> b.value.equals(Optional.ofNullable(text)
+                            .orElseThrow(() -> new IllegalArgumentException("Input text must not be null"))
+            ))
             .findFirst()
             .orElseThrow(() -> new IllegalArgumentException("No matching Enum"));
   }

--- a/src/main/java/it/gov/pagopa/rtp/activator/domain/rtp/TransactionStatus.java
+++ b/src/main/java/it/gov/pagopa/rtp/activator/domain/rtp/TransactionStatus.java
@@ -1,6 +1,7 @@
 package it.gov.pagopa.rtp.activator.domain.rtp;
 
-import lombok.NonNull;
+import org.springframework.lang.NonNull;
+
 import java.util.Arrays;
 
 public enum TransactionStatus {
@@ -19,7 +20,8 @@ public enum TransactionStatus {
     this.value = value;
   }
 
-  public static TransactionStatus fromString(@NonNull final String text) {
+  @NonNull
+  public static TransactionStatus fromString(final String text) {
     return Arrays.stream(TransactionStatus.values())
             .filter(b -> b.value.equals(text))
             .findFirst()

--- a/src/main/java/it/gov/pagopa/rtp/activator/domain/rtp/TransactionStatus.java
+++ b/src/main/java/it/gov/pagopa/rtp/activator/domain/rtp/TransactionStatus.java
@@ -1,7 +1,28 @@
 package it.gov.pagopa.rtp.activator.domain.rtp;
 
+import lombok.NonNull;
+import java.util.Arrays;
+
 public enum TransactionStatus {
 
-  ACTC, ACCP, RJCT, ERROR, CNCL, RJCR
+  ACTC("ACTC"),
+  ACCP("ACCP"),
+  RJCT("RJCT"),
+  ERROR("ERROR"),
+  CNCL("CNCL"),
+  RJCR("RJCR"),
+  ACWC("ACWC");
 
+  private final String value;
+
+  TransactionStatus(String value) {
+    this.value = value;
+  }
+
+  public static TransactionStatus fromString(@NonNull final String text) {
+    return Arrays.stream(TransactionStatus.values())
+            .filter(b -> b.value.equals(text))
+            .findFirst()
+            .orElseThrow(() -> new IllegalArgumentException("No matching Enum"));
+  }
 }

--- a/src/main/java/it/gov/pagopa/rtp/activator/service/callback/CallbackFieldsExtractor.java
+++ b/src/main/java/it/gov/pagopa/rtp/activator/service/callback/CallbackFieldsExtractor.java
@@ -14,10 +14,38 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 
+/**
+ * Utility component responsible for extracting relevant fields from the SEPA callback JSON payload.
+ *
+ * <p>This class is used to extract domain-specific values such as {@link TransactionStatus}
+ * and {@link ResourceID} from nested structures inside a {@link JsonNode}, following the
+ * expected format of SEPA asynchronous callback messages.
+ */
 @Slf4j
 @Component("callbackFieldsExtractor")
 public class CallbackFieldsExtractor {
 
+  /**
+   * Extracts a stream of {@link TransactionStatus} values from the provided SEPA callback JSON.
+   *
+   * <p>This method navigates the structure of the JSON tree under:
+   *
+   * <pre>
+   *   AsynchronousSepaRequestToPayResponse
+   *     └── Document
+   *         └── CdtrPmtActvtnReqStsRpt
+   *             └── OrgnlPmtInfAndSts
+   *                 └── TxInfAndSts
+   *                     └── TxSts
+   * </pre>
+   *
+   * <p>Each textual status is trimmed and mapped to a {@link TransactionStatus} enum. If the status
+   * is unknown, it is logged and mapped to {@link TransactionStatus#ERROR}. If the structure is
+   * missing, the stream fails with an {@link IllegalArgumentException}.
+   *
+   * @param responseNode the full callback JSON payload
+   * @return a {@link Flux} of {@link TransactionStatus} values
+   */
   @NonNull
   public Flux<TransactionStatus> extractTransactionStatusSend(@NonNull final JsonNode responseNode) {
       return Mono.justOrEmpty(responseNode)
@@ -48,6 +76,26 @@ public class CallbackFieldsExtractor {
               .switchIfEmpty(Flux.just(TransactionStatus.ERROR));
   }
 
+  /**
+   * Extracts the {@link ResourceID} from the SEPA callback JSON payload.
+   *
+   * <p>This method navigates the following JSON path to locate the message ID:
+   *
+   * <pre>
+   *   AsynchronousSepaRequestToPayResponse
+   *     └── Document
+   *         └── CdtrPmtActvtnReqStsRpt
+   *             └── OrgnlGrpInfAndSts
+   *                 └── OrgnlMsgId
+   * </pre>
+   *
+   * <p>The extracted message ID is trimmed, validated, and converted into a {@link UUID}, then
+   * wrapped in a {@link ResourceID}. If the field is missing or malformed, an {@link
+   * IllegalArgumentException} is thrown.
+   *
+   * @param responseNode the full callback JSON payload
+   * @return a {@link Mono} containing the {@link ResourceID}
+   */
   @NonNull
   public Mono<ResourceID> extractResourceIDSend(@NonNull final JsonNode responseNode) {
       return Mono.justOrEmpty(responseNode)

--- a/src/main/java/it/gov/pagopa/rtp/activator/service/callback/CallbackFieldsExtractor.java
+++ b/src/main/java/it/gov/pagopa/rtp/activator/service/callback/CallbackFieldsExtractor.java
@@ -9,51 +9,64 @@ import it.gov.pagopa.rtp.activator.utils.JsonNodeUtils;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
+import org.springframework.stereotype.Component;
 
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+@Slf4j
+@Component("callbackFieldsExtractor")
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class CallbackFieldsExtractor {
 
-    @NonNull
-    public static List<TransactionStatus> exstractTransactionStatusSend (@NonNull final JsonNode responseNode) {
-        JsonNode orgnlPmtInfAndSts = Optional.of(responseNode)
-                .map(r -> r.path("AsynchronousSepaRequestToPayResponse")
-                        .path("Document")
-                        .path("CdtrPmtActvtnReqStsRpt")
-                        .path("OrgnlPmtInfAndSts"))
-                .orElseThrow(() -> new IllegalArgumentException("Missing OrgnlPmtInfAndSts field"));
+  @NonNull
+  public List<TransactionStatus> extractTransactionStatusSend(@NonNull final JsonNode responseNode) {
 
-        return JsonNodeUtils.toStream(orgnlPmtInfAndSts)
-                .flatMap(pmt -> JsonNodeUtils.toStream(pmt.path("TxInfAndSts")))
-                .map(t -> t.path("TxSts").asText(null))
-                .map(StringUtils::trimToNull)
-                .map(txtSt -> {
-                    try{
-                        return TransactionStatus.fromString(txtSt);
-                    } catch (IllegalArgumentException e) {
-                        return TransactionStatus.ERROR;
-                    }
-                })
-                .collect(Collectors.toList());
-    }
+      final var orgnlPmtInfAndSts = Optional.of(responseNode)
+              .map(node -> node.path("AsynchronousSepaRequestToPayResponse"))
+              .map(node -> node.path("Document"))
+              .map(node -> node.path("CdtrPmtActvtnReqStsRpt"))
+              .map(node -> node.path("OrgnlPmtInfAndSts"))
+              .filter(node -> !node.isMissingNode())
+              .orElseThrow(() -> new IllegalArgumentException("Missing field"));
 
-    @NonNull
-    public static ResourceID exstractResourceIDSend (@NonNull final JsonNode responseNode) {
-        return Optional.of(responseNode)
-                .map(r -> r.path("AsynchronousSepaRequestToPayResponse")
-                        .path("Document")
-                        .path("CdtrPmtActvtnReqStsRpt")
-                        .path("OrgnlGrpInfAndSts")
-                        .path("OrgnlMsgId")
-                        .asText())
+      final var transactionStatusList = JsonNodeUtils.nodeToCollection(orgnlPmtInfAndSts).stream()
+              .flatMap(node -> JsonNodeUtils.nodeToCollection(node.path("TxInfAndSts")).stream())
+              .flatMap(node -> JsonNodeUtils.nodeToCollection(node.path("TxSts")).stream())
+              .map(node -> node.asText(null))
+              .map(StringUtils::trimToNull)
+              .map(txtSt ->{
+                  try {
+                      return TransactionStatus.fromString(txtSt);
+                  } catch (IllegalArgumentException e) {
+                      return TransactionStatus.ERROR;
+                  }
+              })
+              .collect(Collectors.toList());
+
+      return transactionStatusList.isEmpty() ? List.of(TransactionStatus.ERROR) : transactionStatusList;
+  }
+
+  @NonNull
+  public ResourceID exstractResourceIDSend(@NonNull final JsonNode responseNode) {
+
+        final var orgnlMsgId = Optional.of(responseNode)
+                .map(node -> node.path("AsynchronousSepaRequestToPayResponse"))
+                .map(node -> node.path("Document"))
+                .map(node -> node.path("CdtrPmtActvtnReqStsRpt"))
+                .map(node -> node.path("OrgnlGrpInfAndSts"))
+                .map(node -> node.path("OrgnlMsgId"))
+                .filter(node -> !node.isMissingNode())
+                .orElseThrow(() -> new IllegalArgumentException("Missing field"));
+
+        return Optional.of(orgnlMsgId)
+                .map(JsonNode::asText)
                 .map(StringUtils::trimToNull)
                 .map(IdentifierUtils::uuidRebuilder)
                 .map(ResourceID::new)
-                .orElseThrow(() -> new IllegalArgumentException("Missing OrgnlGrpInfAndSts field"));
+                .orElseThrow(() -> new IllegalArgumentException("Resource id is invalid"));
     }
-
 }

--- a/src/main/java/it/gov/pagopa/rtp/activator/service/callback/CallbackFieldsExtractor.java
+++ b/src/main/java/it/gov/pagopa/rtp/activator/service/callback/CallbackFieldsExtractor.java
@@ -6,8 +6,6 @@ import it.gov.pagopa.rtp.activator.domain.rtp.ResourceID;
 import it.gov.pagopa.rtp.activator.domain.rtp.TransactionStatus;
 import it.gov.pagopa.rtp.activator.utils.IdentifierUtils;
 import it.gov.pagopa.rtp.activator.utils.JsonNodeUtils;
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
@@ -18,7 +16,6 @@ import reactor.core.publisher.Mono;
 
 @Slf4j
 @Component("callbackFieldsExtractor")
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class CallbackFieldsExtractor {
 
   @NonNull
@@ -46,8 +43,7 @@ public class CallbackFieldsExtractor {
   }
 
   @NonNull
-  public Mono<ResourceID> exstractResourceIDSend(@NonNull final JsonNode responseNode) {
-
+  public Mono<ResourceID> extractResourceIDSend(@NonNull final JsonNode responseNode) {
       return Mono.justOrEmpty(responseNode)
               .map(node -> node.path("AsynchronousSepaRequestToPayResponse")
                       .path("Document")

--- a/src/main/java/it/gov/pagopa/rtp/activator/service/callback/CallbackFieldsExtractor.java
+++ b/src/main/java/it/gov/pagopa/rtp/activator/service/callback/CallbackFieldsExtractor.java
@@ -1,0 +1,59 @@
+package it.gov.pagopa.rtp.activator.service.callback;
+
+
+import com.fasterxml.jackson.databind.JsonNode;
+import it.gov.pagopa.rtp.activator.domain.rtp.ResourceID;
+import it.gov.pagopa.rtp.activator.domain.rtp.TransactionStatus;
+import it.gov.pagopa.rtp.activator.utils.IdentifierUtils;
+import it.gov.pagopa.rtp.activator.utils.JsonNodeUtils;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class CallbackFieldsExtractor {
+
+    @NonNull
+    public static List<TransactionStatus> exstractTransactionStatusSend (@NonNull final JsonNode responseNode) {
+        JsonNode orgnlPmtInfAndSts = Optional.of(responseNode)
+                .map(r -> r.path("AsynchronousSepaRequestToPayResponse")
+                        .path("Document")
+                        .path("CdtrPmtActvtnReqStsRpt")
+                        .path("OrgnlPmtInfAndSts"))
+                .orElseThrow(() -> new IllegalArgumentException("Missing OrgnlPmtInfAndSts field"));
+
+        return JsonNodeUtils.toStream(orgnlPmtInfAndSts)
+                .flatMap(pmt -> JsonNodeUtils.toStream(pmt.path("TxInfAndSts")))
+                .map(t -> t.path("TxSts").asText(null))
+                .map(StringUtils::trimToNull)
+                .map(txtSt -> {
+                    try{
+                        return TransactionStatus.fromString(txtSt);
+                    } catch (IllegalArgumentException e) {
+                        return TransactionStatus.ERROR;
+                    }
+                })
+                .collect(Collectors.toList());
+    }
+
+    @NonNull
+    public static ResourceID exstractResourceIDSend (@NonNull final JsonNode responseNode) {
+        return Optional.of(responseNode)
+                .map(r -> r.path("AsynchronousSepaRequestToPayResponse")
+                        .path("Document")
+                        .path("CdtrPmtActvtnReqStsRpt")
+                        .path("OrgnlGrpInfAndSts")
+                        .path("OrgnlMsgId")
+                        .asText())
+                .map(StringUtils::trimToNull)
+                .map(IdentifierUtils::uuidRebuilder)
+                .map(ResourceID::new)
+                .orElseThrow(() -> new IllegalArgumentException("Missing OrgnlGrpInfAndSts field"));
+    }
+
+}

--- a/src/main/java/it/gov/pagopa/rtp/activator/service/callback/CallbackFieldsExtractor.java
+++ b/src/main/java/it/gov/pagopa/rtp/activator/service/callback/CallbackFieldsExtractor.java
@@ -21,10 +21,12 @@ public class CallbackFieldsExtractor {
   @NonNull
   public Flux<TransactionStatus> extractTransactionStatusSend(@NonNull final JsonNode responseNode) {
       return Mono.justOrEmpty(responseNode)
+              .doOnNext(node -> log.debug("Received JSON for transaction status extraction: {}", node))
               .map(node -> node.path("AsynchronousSepaRequestToPayResponse")
                       .path("Document")
                       .path("CdtrPmtActvtnReqStsRpt")
                       .path("OrgnlPmtInfAndSts"))
+              .doOnNext(node -> log.debug("Navigated to OrgnlPmtInfAndSts node: {}", node))
               .filter(node -> !node.isMissingNode())
               .switchIfEmpty(Mono.error(new IllegalArgumentException("Missing field")))
               .flatMapMany(JsonNodeUtils::nodeToFlux)
@@ -32,10 +34,14 @@ public class CallbackFieldsExtractor {
               .flatMap(node -> JsonNodeUtils.nodeToFlux(node.path("TxSts")))
               .map(JsonNode::asText)
               .map(StringUtils::trim)
+              .doOnNext(txSt -> log.debug("Extracted raw transaction status: '{}'", txSt))
               .map(txtSt -> {
                   try {
-                      return TransactionStatus.fromString(txtSt);
+                      TransactionStatus status = TransactionStatus.fromString(txtSt);
+                      log.info("Mapped transaction status to enum: {}", status);
+                      return status;
                   } catch (IllegalArgumentException e) {
+                      log.warn("Invalid transaction status '{}', defaulting to ERROR", txtSt);
                       return TransactionStatus.ERROR;
                   }
               })
@@ -45,17 +51,22 @@ public class CallbackFieldsExtractor {
   @NonNull
   public Mono<ResourceID> extractResourceIDSend(@NonNull final JsonNode responseNode) {
       return Mono.justOrEmpty(responseNode)
+              .doOnNext(node -> log.debug("Received JSON for resource ID extraction: {}", node))
               .map(node -> node.path("AsynchronousSepaRequestToPayResponse")
                       .path("Document")
                       .path("CdtrPmtActvtnReqStsRpt")
                       .path("OrgnlGrpInfAndSts")
                       .path("OrgnlMsgId"))
+              .doOnNext(node -> log.debug("Navigated to OrgnlMsgId node: {}", node))
               .filter(node -> !node.isMissingNode())
               .switchIfEmpty(Mono.error(new IllegalArgumentException("Missing field")))
               .map(JsonNode::asText)
               .map(StringUtils::trim)
+              .doOnNext(value -> log.debug("Extracted original message ID: '{}'", value))
               .map(IdentifierUtils::uuidRebuilder)
+              .doOnNext(uuid -> log.debug("Rebuilt UUID: {}", uuid))
               .map(ResourceID::new)
+              .doOnNext(id -> log.info("Extracted ResourceID: {}", id))
               .switchIfEmpty(Mono.error(new IllegalArgumentException("Resource id is invalid")));
   }
 }

--- a/src/main/java/it/gov/pagopa/rtp/activator/service/callback/CallbackHandler.java
+++ b/src/main/java/it/gov/pagopa/rtp/activator/service/callback/CallbackHandler.java
@@ -1,0 +1,73 @@
+package it.gov.pagopa.rtp.activator.service.callback;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import it.gov.pagopa.rtp.activator.configuration.ServiceProviderConfig;
+import it.gov.pagopa.rtp.activator.domain.rtp.Rtp;
+import it.gov.pagopa.rtp.activator.domain.rtp.RtpRepository;
+import it.gov.pagopa.rtp.activator.domain.rtp.TransactionStatus;
+import it.gov.pagopa.rtp.activator.service.rtp.RtpStatusUpdater;
+import it.gov.pagopa.rtp.activator.utils.RetryPolicyUtils;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.util.Objects;
+import java.util.function.Function;
+
+@Component("callbackHandler")
+@Slf4j
+public class CallbackHandler {
+
+  private final RtpRepository rtpRepository;
+  private final RtpStatusUpdater rtpStatusUpdater;
+  private final ServiceProviderConfig serviceProviderConfig;
+
+  public CallbackHandler(
+          @NonNull RtpRepository rtpRepository,
+          @NonNull RtpStatusUpdater rtpStatusUpdater,
+          @NonNull ServiceProviderConfig serviceProviderConfig) {
+    this.rtpRepository = Objects.requireNonNull(rtpRepository);
+    this.rtpStatusUpdater = Objects.requireNonNull(rtpStatusUpdater);
+    this.serviceProviderConfig = Objects.requireNonNull(serviceProviderConfig);
+  }
+
+  public Mono<JsonNode> handle(@NonNull final JsonNode requestBody) {
+    final var transactionStatus = CallbackFieldsExtractor.exstractTransactionStatusSend(requestBody);
+    final var resourceId = CallbackFieldsExtractor.exstractResourceIDSend(requestBody);
+
+    return rtpRepository.findById(resourceId)
+            .doOnNext( rtp -> log.info("Retrieved RTP with id {}", rtp.resourceID().getId()))
+            .flatMap(rtpToUpdate -> Flux.fromIterable(transactionStatus)
+                            .concatMap(status -> triggerStatus(status, rtpToUpdate))
+                            .then(Mono.just(rtpToUpdate))
+            )
+            .doOnSuccess(r -> log.info("Completed handling callback response"))
+            .thenReturn(requestBody);
+  }
+
+  private Mono<Rtp> triggerStatus(
+      @NonNull final TransactionStatus transactionStatus,
+      @NonNull final Rtp rtpToUpdate) {
+
+      log.debug("Handling TransactionStatus: {}", transactionStatus);
+
+      return switch (transactionStatus) {
+          case ACCP, ACWC -> this.triggerAndSave(rtpToUpdate, this.rtpStatusUpdater::triggerAcceptRtp);
+          case RJCR -> this.triggerAndSave(rtpToUpdate, this.rtpStatusUpdater::triggerRejectRtp);
+          case ERROR -> this.triggerAndSave(rtpToUpdate, this.rtpStatusUpdater::triggerErrorSendRtp);
+          default -> Mono.error(new IllegalStateException("Unsupported TransactionStatus: " + transactionStatus));
+      };
+  }
+
+  private Mono<Rtp> triggerAndSave(@NonNull final Rtp rtpToUpdate,
+                                   @NonNull final Function<Rtp, Mono<Rtp>> transitionFunction) {
+    return transitionFunction.apply(rtpToUpdate)
+            .flatMap(rtpToSave -> rtpRepository.save(rtpToSave)
+                    .doOnNext(r -> log.info("Saved RTP with id {} and status {}", r.resourceID().getId(),rtpToSave.status()))
+                    .retryWhen(RetryPolicyUtils.sendRetryPolicy(serviceProviderConfig.send().retry()))
+                    .doOnError(ex -> log.error("Failed after retries", ex))
+            );
+  }
+}

--- a/src/main/java/it/gov/pagopa/rtp/activator/service/callback/CallbackHandler.java
+++ b/src/main/java/it/gov/pagopa/rtp/activator/service/callback/CallbackHandler.java
@@ -37,7 +37,7 @@ public class CallbackHandler {
 
   public Mono<JsonNode> handle(@NonNull final JsonNode requestBody) {
     final var transactionStatus = callbackFieldsExtractor.extractTransactionStatusSend(requestBody);
-    final var resourceId = callbackFieldsExtractor.exstractResourceIDSend(requestBody);
+    final var resourceId = callbackFieldsExtractor.extractResourceIDSend(requestBody);
 
       return resourceId
               .flatMap(rtpRepository::findById)

--- a/src/main/java/it/gov/pagopa/rtp/activator/utils/IdentifierUtils.java
+++ b/src/main/java/it/gov/pagopa/rtp/activator/utils/IdentifierUtils.java
@@ -53,6 +53,16 @@ public class IdentifierUtils {
         .orElseThrow(() -> new IllegalArgumentException("uuid cannot be null"));
   }
 
+  /**
+   * Reconstructs a {@link UUID} from a compact string without dashes.
+   *
+   * <p>This method takes a UUID string in the compact format (i.e., without dashes) and converts
+   * it to the standard UUID format by inserting dashes at the appropriate positions.
+   *
+   * @param uuidString the UUID string without dashes (must not be null and must match a valid UUID format)
+   * @return the reconstructed {@link UUID} object
+   * @throws IllegalArgumentException if the input is null or does not conform to a valid UUID format
+   */
   @NonNull
   public static UUID uuidRebuilder(@NonNull final String uuidString) {
     return Optional.of(uuidString)

--- a/src/main/java/it/gov/pagopa/rtp/activator/utils/IdentifierUtils.java
+++ b/src/main/java/it/gov/pagopa/rtp/activator/utils/IdentifierUtils.java
@@ -2,8 +2,9 @@ package it.gov.pagopa.rtp.activator.utils;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
-import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.lang.NonNull;
 
 import java.util.Optional;
 import java.util.UUID;
@@ -18,6 +19,22 @@ import java.util.UUID;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class IdentifierUtils {
 
+  private static final String UUID_PATTERN = "^([a-f0-9]{8})-([a-f0-9]{4})-([a-f0-9]{4})-([a-f0-9]{4})-([a-f0-9]{12})$";
+  private static final String DASHES_REMOVER_PATTERN = "$1$2$3$4$5";
+
+  private static final String UUID_WITHOUT_DASHES_PATTERN = "^([a-f0-9]{8})([a-f0-9]{4})([a-f0-9]{4})([a-f0-9]{4})([a-f0-9]{12})$";
+  private static final String DASHES_INSERTER_PATTERN = "$1-$2-$3-$4-$5";
+
+  /**
+   * Checks if the given string is a valid UUID.
+   *
+   * @param uuidString the string to be checked
+   * @return true if the string is a valid UUID, false otherwise
+   */
+  public static boolean isValidUuid(final String uuidString) {
+    return StringUtils.isNotBlank(uuidString) && uuidString.matches(UUID_WITHOUT_DASHES_PATTERN);
+  }
+
   /**
    * Formats a {@link UUID} by removing all hyphens ("-").
    *
@@ -29,10 +46,18 @@ public class IdentifierUtils {
    * @throws IllegalArgumentException if the uuid is null
    */
   @NonNull
-  public static String uuidFormatter(final UUID uuid) {
-    return Optional.ofNullable(uuid)
+  public static String uuidFormatter(@NonNull final UUID uuid) {
+    return Optional.of(uuid)
         .map(UUID::toString)
-        .map(s -> s.replace("-", ""))
+        .map(s -> s.replaceFirst(UUID_PATTERN, DASHES_REMOVER_PATTERN))
         .orElseThrow(() -> new IllegalArgumentException("uuid cannot be null"));
+  }
+
+  @NonNull
+  public static UUID uuidRebuilder(@NonNull final String uuidString) {
+    return Optional.of(uuidString)
+            .map(s -> s.replaceFirst(UUID_WITHOUT_DASHES_PATTERN, DASHES_INSERTER_PATTERN))
+            .map(UUID::fromString)
+            .orElseThrow(() -> new IllegalArgumentException("Invalid UUID format"));
   }
 }

--- a/src/main/java/it/gov/pagopa/rtp/activator/utils/JsonNodeUtils.java
+++ b/src/main/java/it/gov/pagopa/rtp/activator/utils/JsonNodeUtils.java
@@ -5,9 +5,8 @@ import com.fasterxml.jackson.databind.JsonNode;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.springframework.lang.NonNull;
+import reactor.core.publisher.Flux;
 
-import java.util.Collection;
-import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
@@ -16,14 +15,13 @@ import java.util.stream.StreamSupport;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class JsonNodeUtils {
 
-    @NonNull
-    public static Collection<JsonNode> nodeToCollection(@NonNull final JsonNode node) {
+    public static Flux<JsonNode> nodeToFlux(@NonNull final JsonNode node) {
         return Optional.of(node)
                 .filter(JsonNode::isContainerNode)
                 .map(n -> n.isArray()
                         ? StreamSupport.stream(n.spliterator(), false)
                         : Stream.of(n))
-                .map(Stream::toList)
-                .orElseGet(List::of);
+                .map(Flux::fromStream)
+                .orElseGet(Flux::empty);
     }
 }

--- a/src/main/java/it/gov/pagopa/rtp/activator/utils/JsonNodeUtils.java
+++ b/src/main/java/it/gov/pagopa/rtp/activator/utils/JsonNodeUtils.java
@@ -1,0 +1,25 @@
+package it.gov.pagopa.rtp.activator.utils;
+
+
+import com.fasterxml.jackson.databind.JsonNode;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+
+import java.util.Optional;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class JsonNodeUtils {
+
+    public static Stream<JsonNode> toStream(@NonNull JsonNode node) {
+        return Optional.of(node)
+                .filter(JsonNode::isContainerNode)
+                .map(n -> n.isArray()
+                        ? StreamSupport.stream(n.spliterator(), false)
+                        : Stream.of(n))
+                .orElseGet(Stream::empty);
+    }
+}

--- a/src/main/java/it/gov/pagopa/rtp/activator/utils/JsonNodeUtils.java
+++ b/src/main/java/it/gov/pagopa/rtp/activator/utils/JsonNodeUtils.java
@@ -4,8 +4,10 @@ package it.gov.pagopa.rtp.activator.utils;
 import com.fasterxml.jackson.databind.JsonNode;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
-import lombok.NonNull;
+import org.springframework.lang.NonNull;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
@@ -14,12 +16,14 @@ import java.util.stream.StreamSupport;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class JsonNodeUtils {
 
-    public static Stream<JsonNode> toStream(@NonNull JsonNode node) {
+    @NonNull
+    public static Collection<JsonNode> nodeToCollection(@NonNull final JsonNode node) {
         return Optional.of(node)
                 .filter(JsonNode::isContainerNode)
                 .map(n -> n.isArray()
                         ? StreamSupport.stream(n.spliterator(), false)
                         : Stream.of(n))
-                .orElseGet(Stream::empty);
+                .map(Stream::toList)
+                .orElseGet(List::of);
     }
 }

--- a/src/main/java/it/gov/pagopa/rtp/activator/utils/JsonNodeUtils.java
+++ b/src/main/java/it/gov/pagopa/rtp/activator/utils/JsonNodeUtils.java
@@ -12,9 +12,25 @@ import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 
+/**
+ * Utility class for working with Jackson {@link JsonNode} structures in reactive contexts.
+ *
+ * <p>This class provides methods to help convert {@link JsonNode} containers into reactive streams,
+ * particularly useful when traversing dynamic JSON trees using Project Reactor.
+ */
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class JsonNodeUtils {
 
+    /**
+     * Converts a given {@link JsonNode} into a {@link Flux} of child nodes.
+     *
+     * <p>If the provided node is an array, each element in the array will be emitted as a separate
+     * item in the flux. If the node is an object or a primitive container, the node itself will be emitted
+     * as a single item. If the node is not a container (e.g., null, missing, or scalar), an empty flux is returned.
+     *
+     * @param node the {@link JsonNode} to convert (must not be null)
+     * @return a {@link Flux} of {@link JsonNode} elements, one for each item in the array or the node itself
+     */
     public static Flux<JsonNode> nodeToFlux(@NonNull final JsonNode node) {
         return Optional.of(node)
                 .filter(JsonNode::isContainerNode)

--- a/src/main/java/it/gov/pagopa/rtp/activator/utils/RetryPolicyUtils.java
+++ b/src/main/java/it/gov/pagopa/rtp/activator/utils/RetryPolicyUtils.java
@@ -1,6 +1,8 @@
 package it.gov.pagopa.rtp.activator.utils;
 
 import it.gov.pagopa.rtp.activator.configuration.ServiceProviderConfig;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.lang.NonNull;
 import reactor.util.retry.Retry;
@@ -16,6 +18,7 @@ import java.util.Objects;
  * jitter, and maximum attempts, based on application configuration.
  */
 @Slf4j
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class RetryPolicyUtils {
 
     /**

--- a/src/main/java/it/gov/pagopa/rtp/activator/utils/RetryPolicyUtils.java
+++ b/src/main/java/it/gov/pagopa/rtp/activator/utils/RetryPolicyUtils.java
@@ -1,0 +1,28 @@
+package it.gov.pagopa.rtp.activator.utils;
+
+import it.gov.pagopa.rtp.activator.configuration.ServiceProviderConfig;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.lang.NonNull;
+import reactor.util.retry.Retry;
+import reactor.util.retry.RetryBackoffSpec;
+
+import java.time.Duration;
+import java.util.Objects;
+
+@Slf4j
+public class RetryPolicyUtils {
+
+    @NonNull
+    public static RetryBackoffSpec sendRetryPolicy(@NonNull final ServiceProviderConfig.Send.Retry retryParams) {
+
+        Objects.requireNonNull(retryParams, "Retry parameters cannot be null");
+
+        final var maxAttempts = retryParams.maxAttempts();
+        final var minDurationMillis = retryParams.backoffMinDuration();
+        final var jitter = retryParams.backoffJitter();
+
+        return Retry.backoff(maxAttempts, Duration.ofMillis(minDurationMillis))
+                .jitter(jitter)
+                .doAfterRetry(signal -> log.info("Retry number {}", signal.totalRetries()));
+    }
+}

--- a/src/main/java/it/gov/pagopa/rtp/activator/utils/RetryPolicyUtils.java
+++ b/src/main/java/it/gov/pagopa/rtp/activator/utils/RetryPolicyUtils.java
@@ -9,9 +9,25 @@ import reactor.util.retry.RetryBackoffSpec;
 import java.time.Duration;
 import java.util.Objects;
 
+/**
+ * Utility class for creating retry policies using Project Reactor's {@link Retry} API.
+ *
+ * <p>This class provides helper methods to configure retry strategies, such as backoff duration,
+ * jitter, and maximum attempts, based on application configuration.
+ */
 @Slf4j
 public class RetryPolicyUtils {
 
+    /**
+     * Creates a {@link RetryBackoffSpec} based on the provided retry configuration parameters.
+     *
+     * <p>This retry policy uses exponential backoff with optional jitter to space out retry attempts.
+     * Each retry is logged with its current attempt count.
+     *
+     * @param retryParams the configuration parameters for retry (must not be null)
+     * @return a configured {@link RetryBackoffSpec} instance
+     * @throws NullPointerException if {@code retryParams} is null
+     */
     @NonNull
     public static RetryBackoffSpec sendRetryPolicy(@NonNull final ServiceProviderConfig.Send.Retry retryParams) {
 

--- a/src/test/java/it/gov/pagopa/rtp/activator/domain/rtp/TransactionStatusTest.java
+++ b/src/test/java/it/gov/pagopa/rtp/activator/domain/rtp/TransactionStatusTest.java
@@ -1,0 +1,54 @@
+package it.gov.pagopa.rtp.activator.domain.rtp;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class TransactionStatusTest {
+
+    @Test
+    void givenValidStatusString_whenFromString_thenReturnCorrectEnum() {
+        String input = "ACCP";
+
+        TransactionStatus result = TransactionStatus.fromString(input);
+
+        assertEquals(TransactionStatus.ACCP, result);
+    }
+
+    @Test
+    void givenEmptyString_whenFromString_thenThrowIllegalArgumentException() {
+        String input = "";
+
+        IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> TransactionStatus.fromString(input)
+        );
+
+        assertEquals("No matching Enum", exception.getMessage());
+    }
+
+    @Test
+    void givenInvalidStatusString_whenFromString_thenThrowIllegalArgumentException() {
+        String input = "INVALID";
+
+        IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> TransactionStatus.fromString(input)
+        );
+
+        assertEquals("No matching Enum", exception.getMessage());
+    }
+
+    @Test
+    void givenNull_whenFromString_thenThrowIllegalArgumentException() {
+        String input = null;
+
+        IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> TransactionStatus.fromString(input)
+        );
+
+        assertEquals("Input text must not be null", exception.getMessage());
+    }
+
+}

--- a/src/test/java/it/gov/pagopa/rtp/activator/domain/rtp/TransactionStatusTest.java
+++ b/src/test/java/it/gov/pagopa/rtp/activator/domain/rtp/TransactionStatusTest.java
@@ -1,6 +1,8 @@
 package it.gov.pagopa.rtp.activator.domain.rtp;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -15,39 +17,24 @@ class TransactionStatusTest {
         assertEquals(TransactionStatus.ACCP, result);
     }
 
-    @Test
-    void givenEmptyString_whenFromString_thenThrowIllegalArgumentException() {
-        String input = "";
-
+    @ParameterizedTest
+    @ValueSource(strings = {"", "INVALID"})
+    void givenInvalidStringInput_whenFromString_thenThrowsIllegalArgumentException(String input) {
         IllegalArgumentException exception = assertThrows(
                 IllegalArgumentException.class,
                 () -> TransactionStatus.fromString(input)
         );
-
         assertEquals("No matching Enum", exception.getMessage());
     }
 
     @Test
-    void givenInvalidStatusString_whenFromString_thenThrowIllegalArgumentException() {
-        String input = "INVALID";
-
-        IllegalArgumentException exception = assertThrows(
-                IllegalArgumentException.class,
-                () -> TransactionStatus.fromString(input)
-        );
-
-        assertEquals("No matching Enum", exception.getMessage());
-    }
-
-    @Test
-    void givenNull_whenFromString_thenThrowIllegalArgumentException() {
+    void givenNullInput_whenFromString_thenThrowsIllegalArgumentException() {
         String input = null;
 
         IllegalArgumentException exception = assertThrows(
                 IllegalArgumentException.class,
                 () -> TransactionStatus.fromString(input)
         );
-
         assertEquals("Input text must not be null", exception.getMessage());
     }
 

--- a/src/test/java/it/gov/pagopa/rtp/activator/service/callback/CallbackFieldsExtractorTest.java
+++ b/src/test/java/it/gov/pagopa/rtp/activator/service/callback/CallbackFieldsExtractorTest.java
@@ -1,0 +1,182 @@
+package it.gov.pagopa.rtp.activator.service.callback;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import it.gov.pagopa.rtp.activator.domain.rtp.TransactionStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import reactor.test.StepVerifier;
+
+import java.util.UUID;
+
+
+class CallbackFieldsExtractorTest {
+
+    private CallbackFieldsExtractor extractor;
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        extractor = new CallbackFieldsExtractor();
+        objectMapper = new ObjectMapper();
+    }
+
+    @Test
+    void givenValidJson_whenExtractTransactionStatusSend_thenReturnTransactionStatuses() throws Exception {
+        String json = """
+            {
+              "AsynchronousSepaRequestToPayResponse": {
+                "Document": {
+                  "CdtrPmtActvtnReqStsRpt": {
+                    "OrgnlPmtInfAndSts": [
+                      {
+                        "TxInfAndSts": [
+                          {
+                            "TxSts": ["ACCP"]
+                          },
+                          {
+                            "TxSts": ["RJCT"]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+        """;
+        JsonNode node = objectMapper.readTree(json);
+
+        var result = extractor.extractTransactionStatusSend(node);
+
+        StepVerifier.create(result)
+                .expectNext(TransactionStatus.ACCP)
+                .expectNext(TransactionStatus.RJCT)
+                .verifyComplete();
+    }
+
+    @Test
+    void givenUnknownStatus_whenExtractTransactionStatusSend_thenReturnErrorStatus() throws Exception {
+        String json = """
+            {
+              "AsynchronousSepaRequestToPayResponse": {
+                "Document": {
+                  "CdtrPmtActvtnReqStsRpt": {
+                    "OrgnlPmtInfAndSts": [
+                      {
+                        "TxInfAndSts": [
+                          {
+                            "TxSts": ["FOO"]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+        """;
+        JsonNode node = objectMapper.readTree(json);
+
+        var result = extractor.extractTransactionStatusSend(node);
+
+        StepVerifier.create(result)
+                .expectNext(TransactionStatus.ERROR)
+                .verifyComplete();
+    }
+
+    @Test
+    void givenMissingOrgnlPmtInfAndSts_whenExtractTransactionStatusSend_thenThrow() throws Exception {
+        String json = """
+            {
+              "AsynchronousSepaRequestToPayResponse": {
+                "Document": {
+                  "CdtrPmtActvtnReqStsRpt": {}
+                }
+              }
+            }
+        """;
+        JsonNode node = objectMapper.readTree(json);
+
+        var result = extractor.extractTransactionStatusSend(node);
+
+        StepVerifier.create(result)
+                .expectErrorMatches(e ->
+                        e instanceof IllegalArgumentException &&
+                                e.getMessage().equals("Missing field"))
+                .verify();
+    }
+
+    @Test
+    void givenValidJson_whenExtractResourceIDSend_thenReturnResourceID() throws Exception {
+        String uuid = UUID.randomUUID().toString();
+        String json = """
+            {
+              "AsynchronousSepaRequestToPayResponse": {
+                "Document": {
+                  "CdtrPmtActvtnReqStsRpt": {
+                    "OrgnlGrpInfAndSts": {
+                      "OrgnlMsgId": "%s"
+                    }
+                  }
+                }
+              }
+            }
+        """.formatted(uuid);
+        JsonNode node = objectMapper.readTree(json);
+
+        var result = extractor.extractResourceIDSend(node);
+
+        StepVerifier.create(result)
+                .expectNextMatches(resourceID -> resourceID.getId().toString().equals(uuid))
+                .verifyComplete();
+    }
+
+    @Test
+    void givenMissingMsgId_whenExtractResourceIDSend_thenThrow() throws Exception {
+        String json = """
+            {
+              "AsynchronousSepaRequestToPayResponse": {
+                "Document": {
+                  "CdtrPmtActvtnReqStsRpt": {
+                    "OrgnlGrpInfAndSts": {}
+                  }
+                }
+              }
+            }
+        """;
+        JsonNode node = objectMapper.readTree(json);
+
+        var result = extractor.extractResourceIDSend(node);
+
+        StepVerifier.create(result)
+                .expectErrorMatches(e ->
+                        e instanceof IllegalArgumentException &&
+                                e.getMessage().equals("Missing field"))
+                .verify();
+    }
+
+    @Test
+    void givenInvalidUuid_whenExtractResourceIDSend_thenThrow() throws Exception {
+        String json = """
+            {
+              "AsynchronousSepaRequestToPayResponse": {
+                "Document": {
+                  "CdtrPmtActvtnReqStsRpt": {
+                    "OrgnlGrpInfAndSts": {
+                      "OrgnlMsgId": "not-a-uuid"
+                    }
+                  }
+                }
+              }
+            }
+        """;
+        JsonNode node = objectMapper.readTree(json);
+
+        var result = extractor.extractResourceIDSend(node);
+
+        StepVerifier.create(result)
+                .expectError(IllegalArgumentException.class)
+                .verify();
+    }
+}

--- a/src/test/java/it/gov/pagopa/rtp/activator/service/callback/CallbackHandlerTest.java
+++ b/src/test/java/it/gov/pagopa/rtp/activator/service/callback/CallbackHandlerTest.java
@@ -1,0 +1,208 @@
+package it.gov.pagopa.rtp.activator.service.callback;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import it.gov.pagopa.rtp.activator.configuration.ServiceProviderConfig;
+import it.gov.pagopa.rtp.activator.domain.rtp.*;
+import it.gov.pagopa.rtp.activator.service.rtp.RtpStatusUpdater;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class CallbackHandlerTest {
+
+    @Mock
+    private RtpRepository rtpRepository;
+    @Mock
+    private RtpStatusUpdater rtpStatusUpdater;
+    @Mock
+    private ServiceProviderConfig serviceProviderConfig;
+    @Mock
+    private CallbackFieldsExtractor callbackFieldsExtractor;
+
+    @InjectMocks
+    private CallbackHandler callbackHandler;
+
+    @Mock
+    private ServiceProviderConfig.Send sendConfig;
+    @Mock
+    private ServiceProviderConfig.Send.Retry retryConfig;
+
+    private final ResourceID resourceID = new ResourceID(UUID.randomUUID());
+    private final Rtp rtp = Rtp.builder().resourceID(resourceID).status(RtpStatus.CREATED).build();
+
+    @BeforeEach
+    void setup() {
+        lenient().when(serviceProviderConfig.send()).thenReturn(sendConfig);
+        lenient().when(sendConfig.retry()).thenReturn(retryConfig);
+    }
+
+    @Test
+    void givenValidACCPStatus_whenHandle_thenAcceptTriggeredAndSaved() {
+        JsonNode request = mock(JsonNode.class);
+
+        when(callbackFieldsExtractor.extractTransactionStatusSend(request))
+                .thenReturn(Flux.just(TransactionStatus.ACCP));
+        when(callbackFieldsExtractor.extractResourceIDSend(request))
+                .thenReturn(Mono.just(resourceID));
+        when(rtpRepository.findById(resourceID))
+                .thenReturn(Mono.just(rtp));
+        when(rtpStatusUpdater.triggerAcceptRtp(rtp))
+                .thenReturn(Mono.just(rtp));
+        when(rtpRepository.save(any(Rtp.class)))
+                .thenReturn(Mono.just(rtp));
+
+        StepVerifier.create(callbackHandler.handle(request))
+                .expectNext(request)
+                .verifyComplete();
+
+        verify(rtpStatusUpdater).triggerAcceptRtp(rtp);
+        verify(rtpRepository).save(rtp);
+    }
+
+    @Test
+    void givenValidRJCTStatus_whenHandle_thenRejectTriggeredAndSaved() {
+        JsonNode request = mock(JsonNode.class);
+
+        when(callbackFieldsExtractor.extractTransactionStatusSend(request))
+                .thenReturn(Flux.just(TransactionStatus.RJCT));
+        when(callbackFieldsExtractor.extractResourceIDSend(request))
+                .thenReturn(Mono.just(resourceID));
+        when(rtpRepository.findById(resourceID))
+                .thenReturn(Mono.just(rtp));
+        when(rtpStatusUpdater.triggerRejectRtp(rtp))
+                .thenReturn(Mono.just(rtp));
+        when(rtpRepository.save(any(Rtp.class)))
+                .thenReturn(Mono.just(rtp));
+
+        StepVerifier.create(callbackHandler.handle(request))
+                .expectNext(request)
+                .verifyComplete();
+
+        verify(rtpStatusUpdater).triggerRejectRtp(rtp);
+    }
+
+    @Test
+    void givenValidERRORStatus_whenHandle_thenErrorTriggeredAndSaved() {
+        JsonNode request = mock(JsonNode.class);
+
+        when(callbackFieldsExtractor.extractTransactionStatusSend(request))
+                .thenReturn(Flux.just(TransactionStatus.ERROR));
+        when(callbackFieldsExtractor.extractResourceIDSend(request))
+                .thenReturn(Mono.just(resourceID));
+        when(rtpRepository.findById(resourceID))
+                .thenReturn(Mono.just(rtp));
+        when(rtpStatusUpdater.triggerErrorSendRtp(rtp))
+                .thenReturn(Mono.just(rtp));
+        when(rtpRepository.save(any(Rtp.class)))
+                .thenReturn(Mono.just(rtp));
+
+        StepVerifier.create(callbackHandler.handle(request))
+                .expectNext(request)
+                .verifyComplete();
+
+        verify(rtpStatusUpdater).triggerErrorSendRtp(rtp);
+    }
+
+    @Test
+    void givenInvalidTransactionStatus_whenHandle_thenIllegalStateExceptionThrown() {
+        JsonNode request = mock(JsonNode.class);
+
+        when(callbackFieldsExtractor.extractTransactionStatusSend(request))
+                .thenReturn(Flux.just(TransactionStatus.ACTC));
+        when(callbackFieldsExtractor.extractResourceIDSend(request))
+                .thenReturn(Mono.just(resourceID));
+        when(rtpRepository.findById(resourceID))
+                .thenReturn(Mono.just(rtp));
+
+        StepVerifier.create(callbackHandler.handle(request))
+                .expectError(IllegalStateException.class)
+                .verify();
+    }
+
+    @Test
+    void givenMissingResourceId_whenHandle_thenIllegalArgumentExceptionThrown() {
+        JsonNode request = mock(JsonNode.class);
+
+        when(callbackFieldsExtractor.extractResourceIDSend(request))
+                .thenReturn(Mono.error(new IllegalArgumentException("Missing field")));
+
+        StepVerifier.create(callbackHandler.handle(request))
+                .expectError(IllegalArgumentException.class)
+                .verify();
+    }
+
+    @Test
+    void givenTransactionStatusExtractionFails_whenHandle_thenErrorThrown() {
+        JsonNode request = mock(JsonNode.class);
+
+        when(callbackFieldsExtractor.extractResourceIDSend(request))
+                .thenReturn(Mono.just(resourceID));
+        when(rtpRepository.findById(resourceID))
+                .thenReturn(Mono.just(rtp));
+        when(callbackFieldsExtractor.extractTransactionStatusSend(request))
+                .thenReturn(Flux.error(new IllegalArgumentException("Malformed transactionStatus")));
+
+        StepVerifier.create(callbackHandler.handle(request))
+                .expectError(IllegalArgumentException.class)
+                .verify();
+    }
+
+    @Test
+    void givenErrorInSave_whenHandle_thenErrorThrown() {
+        JsonNode request = mock(JsonNode.class);
+
+        when(callbackFieldsExtractor.extractTransactionStatusSend(request))
+                .thenReturn(Flux.just(TransactionStatus.ACCP));
+        when(callbackFieldsExtractor.extractResourceIDSend(request))
+                .thenReturn(Mono.just(resourceID));
+        when(rtpRepository.findById(resourceID))
+                .thenReturn(Mono.just(rtp));
+        when(rtpStatusUpdater.triggerAcceptRtp(rtp))
+                .thenReturn(Mono.just(rtp));
+        when(rtpRepository.save(any()))
+                .thenReturn(Mono.error(new RuntimeException("DB down")));
+
+        StepVerifier.create(callbackHandler.handle(request))
+                .expectError(RuntimeException.class)
+                .verify();
+    }
+
+    @Test
+    void givenMultipleTransactionStatuses_whenHandle_thenAllProcessedSequentially() {
+        JsonNode request = mock(JsonNode.class);
+
+        when(callbackFieldsExtractor.extractTransactionStatusSend(request))
+                .thenReturn(Flux.just(TransactionStatus.ACCP, TransactionStatus.RJCT));
+        when(callbackFieldsExtractor.extractResourceIDSend(request))
+                .thenReturn(Mono.just(resourceID));
+        when(rtpRepository.findById(resourceID))
+                .thenReturn(Mono.just(rtp));
+        when(rtpStatusUpdater.triggerAcceptRtp(rtp))
+                .thenReturn(Mono.just(rtp));
+        when(rtpStatusUpdater.triggerRejectRtp(rtp))
+                .thenReturn(Mono.just(rtp));
+        when(rtpRepository.save(any()))
+                .thenReturn(Mono.just(rtp));
+
+        StepVerifier.create(callbackHandler.handle(request))
+                .expectNext(request)
+                .verifyComplete();
+
+        verify(rtpStatusUpdater).triggerAcceptRtp(rtp);
+        verify(rtpStatusUpdater).triggerRejectRtp(rtp);
+        verify(rtpRepository, times(2)).save(rtp);
+    }
+
+}

--- a/src/test/java/it/gov/pagopa/rtp/activator/utils/IdentifierUtilsTest.java
+++ b/src/test/java/it/gov/pagopa/rtp/activator/utils/IdentifierUtilsTest.java
@@ -1,6 +1,9 @@
 package it.gov.pagopa.rtp.activator.utils;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.UUID;
 
@@ -28,25 +31,21 @@ class IdentifierUtilsTest {
     void givenEmptyString_whenUuidFormatter_thenThrowIllegalArgumentException() {
         String emptyString = "";
 
-        IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, () -> {
-            UUID uuid = UUID.fromString(emptyString);
-            IdentifierUtils.uuidFormatter(uuid);
-        });
+        IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class,
+                () -> IdentifierUtils.uuidFormatter(UUID.fromString(emptyString))
+        );
 
         assertEquals("Invalid UUID string: ", thrown.getMessage());
     }
 
     @Test
     void givenValidUuidWithoutDashes_whenUuidRebuilder_thenReturnsProperUuid() {
-        // Given
         String uuidWithoutDashes = "123e4567e89b12d3a456426614174000";
         String expectedFormatted = "123e4567-e89b-12d3-a456-426614174000";
         UUID expectedUuid = UUID.fromString(expectedFormatted);
 
-        // When
         UUID result = IdentifierUtils.uuidRebuilder(uuidWithoutDashes);
 
-        // Then
         assertEquals(expectedUuid, result);
     }
 
@@ -80,27 +79,14 @@ class IdentifierUtilsTest {
         assertTrue(IdentifierUtils.isValidUuid(input));
     }
 
-    @Test
-    void givenUuidWithDashes_whenIsValidUuid_thenReturnsFalse() {
-        String input = "123e4567-e89b-12d3-a456-426614174000";
-        assertFalse(IdentifierUtils.isValidUuid(input));
-    }
-
-    @Test
-    void givenBlankString_whenIsValidUuid_thenReturnsFalse() {
-        String input = " ";
-        assertFalse(IdentifierUtils.isValidUuid(input));
-    }
-
-    @Test
-    void givenNull_whenIsValidUuid_thenReturnsFalse() {
-        String input = null;
-        assertFalse(IdentifierUtils.isValidUuid(input));
-    }
-
-    @Test
-    void givenStringWithInvalidCharacters_whenIsValidUuid_thenReturnsFalse() {
-        String input = "123e4567e89b12d3a45642661417zzzz";
+    @ParameterizedTest
+    @NullSource
+    @ValueSource(strings = {
+            "123e4567-e89b-12d3-a456-426614174000",
+            " ",
+            "123e4567e89b12d3a45642661417zzzz"
+    })
+    void givenInvalidUuidInputs_whenIsValidUuid_thenReturnsFalse(String input) {
         assertFalse(IdentifierUtils.isValidUuid(input));
     }
 }

--- a/src/test/java/it/gov/pagopa/rtp/activator/utils/IdentifierUtilsTest.java
+++ b/src/test/java/it/gov/pagopa/rtp/activator/utils/IdentifierUtilsTest.java
@@ -18,11 +18,10 @@ class IdentifierUtilsTest {
     }
 
     @Test
-    void givenNullUuid_whenUuidFormatter_thenThrowIllegalArgumentException() {
+    void givenNullUuid_whenUuidFormatter_thenThrowNullPointerException() {
         UUID uuid = null;
 
-        IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, () -> IdentifierUtils.uuidFormatter(uuid));
-        assertEquals("uuid cannot be null", thrown.getMessage());
+        assertThrows(NullPointerException.class, () -> IdentifierUtils.uuidFormatter(uuid));
     }
 
     @Test
@@ -35,5 +34,73 @@ class IdentifierUtilsTest {
         });
 
         assertEquals("Invalid UUID string: ", thrown.getMessage());
+    }
+
+    @Test
+    void givenValidUuidWithoutDashes_whenUuidRebuilder_thenReturnsProperUuid() {
+        // Given
+        String uuidWithoutDashes = "123e4567e89b12d3a456426614174000";
+        String expectedFormatted = "123e4567-e89b-12d3-a456-426614174000";
+        UUID expectedUuid = UUID.fromString(expectedFormatted);
+
+        // When
+        UUID result = IdentifierUtils.uuidRebuilder(uuidWithoutDashes);
+
+        // Then
+        assertEquals(expectedUuid, result);
+    }
+
+    @Test
+    void givenUuidWithDashes_whenUuidRebuilder_thenReturnsSameUuid() {
+        String uuidWithDashes = "123e4567-e89b-12d3-a456-426614174000";
+        UUID expectedUuid = UUID.fromString(uuidWithDashes);
+
+        UUID result = IdentifierUtils.uuidRebuilder(uuidWithDashes);
+
+        assertEquals(expectedUuid, result);
+    }
+
+    @Test
+    void givenInvalidUuid_whenUuidRebuilder_thenThrowsIllegalArgumentException() {
+        String invalidUuid = "invalid-uuid-string";
+
+        assertThrows(IllegalArgumentException.class, () -> IdentifierUtils.uuidRebuilder(invalidUuid));
+    }
+
+    @Test
+    void givenNullUuidString_whenUuidRebuilder_thenThrowsNullPointerException() {
+        String nullUuid = null;
+
+        assertThrows(NullPointerException.class, () -> IdentifierUtils.uuidRebuilder(nullUuid));
+    }
+
+    @Test
+    void givenValidUuidWithoutDashes_whenIsValidUuid_thenReturnsTrue() {
+        String input = "123e4567e89b12d3a456426614174000";
+        assertTrue(IdentifierUtils.isValidUuid(input));
+    }
+
+    @Test
+    void givenUuidWithDashes_whenIsValidUuid_thenReturnsFalse() {
+        String input = "123e4567-e89b-12d3-a456-426614174000";
+        assertFalse(IdentifierUtils.isValidUuid(input));
+    }
+
+    @Test
+    void givenBlankString_whenIsValidUuid_thenReturnsFalse() {
+        String input = " ";
+        assertFalse(IdentifierUtils.isValidUuid(input));
+    }
+
+    @Test
+    void givenNull_whenIsValidUuid_thenReturnsFalse() {
+        String input = null;
+        assertFalse(IdentifierUtils.isValidUuid(input));
+    }
+
+    @Test
+    void givenStringWithInvalidCharacters_whenIsValidUuid_thenReturnsFalse() {
+        String input = "123e4567e89b12d3a45642661417zzzz";
+        assertFalse(IdentifierUtils.isValidUuid(input));
     }
 }

--- a/src/test/java/it/gov/pagopa/rtp/activator/utils/IdentifierUtilsTest.java
+++ b/src/test/java/it/gov/pagopa/rtp/activator/utils/IdentifierUtilsTest.java
@@ -28,15 +28,23 @@ class IdentifierUtilsTest {
     }
 
     @Test
-    void givenEmptyString_whenUuidFormatter_thenThrowIllegalArgumentException() {
-        String emptyString = "";
+    void givenValidUpperCaseUuid_whenUuidFormatter_thenFormattedToLowerCaseWithoutHyphens() {
+        UUID uuid = UUID.fromString("123E4567-E89B-12D3-A456-426614174000");
 
-        IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class,
-                () -> IdentifierUtils.uuidFormatter(UUID.fromString(emptyString))
-        );
+        String result = IdentifierUtils.uuidFormatter(uuid);
 
-        assertEquals("Invalid UUID string: ", thrown.getMessage());
+        assertEquals("123e4567e89b12d3a456426614174000", result);
     }
+
+    @Test
+    void givenFormattedUuid_whenRebuilt_thenEqualsOriginal() {
+        UUID originalUuid = UUID.randomUUID();
+        String formatted = IdentifierUtils.uuidFormatter(originalUuid);
+        UUID rebuilt = IdentifierUtils.uuidRebuilder(formatted);
+
+        assertEquals(originalUuid, rebuilt);
+    }
+
 
     @Test
     void givenValidUuidWithoutDashes_whenUuidRebuilder_thenReturnsProperUuid() {
@@ -48,6 +56,14 @@ class IdentifierUtilsTest {
 
         assertEquals(expectedUuid, result);
     }
+
+    @Test
+    void givenNonHexUuidWithoutDashes_whenUuidRebuilder_thenThrowsException() {
+        String invalidHex = "123e4567e89b12d3a45642661417400g"; // 'g' è fuori dal range esadecimale
+
+        assertThrows(IllegalArgumentException.class, () -> IdentifierUtils.uuidRebuilder(invalidHex));
+    }
+
 
     @Test
     void givenUuidWithDashes_whenUuidRebuilder_thenReturnsSameUuid() {
@@ -89,4 +105,14 @@ class IdentifierUtilsTest {
     void givenInvalidUuidInputs_whenIsValidUuid_thenReturnsFalse(String input) {
         assertFalse(IdentifierUtils.isValidUuid(input));
     }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "123e4567e89b12d3a45642661417400",
+            "123e4567e89b12d3a4564266141740000"
+    })
+    void givenUuidWithWrongLength_whenIsValidUuid_thenReturnsFalse(String input) {
+        assertFalse(IdentifierUtils.isValidUuid(input));
+    }
+
 }

--- a/src/test/java/it/gov/pagopa/rtp/activator/utils/JsonNodeUtilsTest.java
+++ b/src/test/java/it/gov/pagopa/rtp/activator/utils/JsonNodeUtilsTest.java
@@ -1,0 +1,59 @@
+package it.gov.pagopa.rtp.activator.utils;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+import reactor.test.StepVerifier;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class JsonNodeUtilsTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    void givenArrayNode_whenNodeToFlux_thenReturnFluxOfElements() throws IOException {
+        String jsonArray = "[{\"field\": \"value1\"}, {\"field\": \"value2\"}]";
+        JsonNode arrayNode = objectMapper.readTree(jsonArray);
+
+        Flux<JsonNode> result = JsonNodeUtils.nodeToFlux(arrayNode);
+
+        StepVerifier.create(result)
+                .expectNextMatches(n -> n.get("field").asText().equals("value1"))
+                .expectNextMatches(n -> n.get("field").asText().equals("value2"))
+                .verifyComplete();
+    }
+
+    @Test
+    void givenObjectNode_whenNodeToFlux_thenReturnFluxWithSingleElement() throws IOException {
+        String jsonObject = "{\"field\": \"value\"}";
+        JsonNode objectNode = objectMapper.readTree(jsonObject);
+
+        Flux<JsonNode> result = JsonNodeUtils.nodeToFlux(objectNode);
+
+        StepVerifier.create(result)
+                .expectNextMatches(n -> n.get("field").asText().equals("value"))
+                .verifyComplete();
+    }
+
+    @Test
+    void givenValueNode_whenNodeToFlux_thenReturnEmptyFlux() throws IOException {
+        String jsonValue = "\"just a string\"";
+        JsonNode valueNode = objectMapper.readTree(jsonValue);
+
+        Flux<JsonNode> result = JsonNodeUtils.nodeToFlux(valueNode);
+
+        StepVerifier.create(result)
+                .verifyComplete();
+    }
+
+    @Test
+    void givenNullInput_whenNodeToFlux_thenThrowNullPointerException() {
+        JsonNode nullNode = null;
+
+        assertThrows(NullPointerException.class, () -> JsonNodeUtils.nodeToFlux(nullNode));
+    }
+}

--- a/src/test/java/it/gov/pagopa/rtp/activator/utils/RetryPolicyUtilsTest.java
+++ b/src/test/java/it/gov/pagopa/rtp/activator/utils/RetryPolicyUtilsTest.java
@@ -1,0 +1,79 @@
+package it.gov.pagopa.rtp.activator.utils;
+
+import it.gov.pagopa.rtp.activator.configuration.ServiceProviderConfig;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+import reactor.util.retry.RetryBackoffSpec;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class RetryPolicyUtilsTest {
+
+    @Test
+    void givenValidRetryParams_whenSendRetryPolicy_thenReturnsRetryBackoffSpec() {
+        ServiceProviderConfig.Send.Retry retryParams = mock(ServiceProviderConfig.Send.Retry.class);
+        when(retryParams.maxAttempts()).thenReturn(3L);
+        when(retryParams.backoffMinDuration()).thenReturn(1000L);
+        when(retryParams.backoffJitter()).thenReturn(0.5d);
+
+        RetryBackoffSpec retryPolicy = RetryPolicyUtils.sendRetryPolicy(retryParams);
+
+        assertNotNull(retryPolicy);
+        assertInstanceOf(RetryBackoffSpec.class, retryPolicy);
+    }
+
+    @Test
+    void givenNullRetryParams_whenSendRetryPolicy_thenThrowsNullPointerException() {
+        ServiceProviderConfig.Send.Retry retryParams = null;
+
+        NullPointerException exception = assertThrows(NullPointerException.class, () ->
+                RetryPolicyUtils.sendRetryPolicy(retryParams));
+        assertEquals("Retry parameters cannot be null", exception.getMessage());
+    }
+
+    @Test
+    void givenFailingMono_whenUsingRetryPolicy_thenRetriesAndSucceeds() {
+        ServiceProviderConfig.Send.Retry retryParams = new ServiceProviderConfig.Send.Retry(3, 100, 0.0);
+
+        var retrySpec = RetryPolicyUtils.sendRetryPolicy(retryParams);
+        AtomicInteger counter = new AtomicInteger();
+
+        Mono<String> unreliableMono = Mono.defer(() -> {
+            if (counter.incrementAndGet() < 3) {
+                return Mono.error(new RuntimeException("Temporary failure"));
+            } else {
+                return Mono.just("Success!");
+            }
+        }).retryWhen(retrySpec);
+
+        StepVerifier.create(unreliableMono)
+                .expectNext("Success!")
+                .verifyComplete();
+
+        assertEquals(3, counter.get());
+    }
+
+    @Test
+    void givenAlwaysFailingMono_whenUsingRetryPolicy_thenRetriesAndFailsWithOriginalCause() {
+    ServiceProviderConfig.Send.Retry retryParams =
+        new ServiceProviderConfig.Send.Retry(2, 100, 0.0);
+        var retrySpec = RetryPolicyUtils.sendRetryPolicy(retryParams);
+
+        Mono<String> alwaysFailingMono = Mono.<String>error(new RuntimeException("Always fails"))
+                .retryWhen(retrySpec);
+
+        StepVerifier.create(alwaysFailingMono)
+                .expectErrorMatches(throwable ->
+                        throwable.getCause() instanceof RuntimeException &&
+                                throwable.getCause().getMessage().contains("Always fails"))
+                .verify();
+    }
+
+
+
+}


### PR DESCRIPTION
#### Description
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This pull request introduces the correct handling of the transaction status received via asynchronous callback from the external stakeholder  within the Request-To-Pay flow.
The goal is to extract the status from the JSON payload and serialize it into the system’s history by applying the appropriate transition to the Rtp domain entity, ensuring consistency and observability across the flow.

#### List of Changes
<!--- Describe your changes in detail -->
- Introduced a new utility class, JsonNodeUtils, to convert JsonNode containers into reactive Flux streams. This simplifies
traversal of nested JSON structures in a non-blocking.

- In IdentifierUtils, added the uuidRebuilder method to reconstruct standard UUIDs from compact string representations without dashes.

- The TransactionStatus enum was enhanced with a fromString() method to safely map external string values to known status types, using ERROR as fallback for unsupported values.

- Created RetryPolicyUtils, a centralized helper for applying exponential backoff and jitter-based retry strategies using Reactor’s Retry API.

- Implemented CallbackFieldsExtractor to parse the SEPA callback payload. It extracts one or more TransactionStatus values and a ResourceID, performing validation, fallback, and detailed logging along the way.

- CallbackHandler orchestrates the full callback processing pipeline: it retrieves the relevant RTP entity, applies the correct transition according to the extracted status, and persists the changes using the retry logic above.

- Finally, the RequestToPayUpdateController was updated to invoke the new CallbackHandler.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change was introduced to ensure that, upon receiving a callback from the external stakeholder, the system is able to properly interpret and persist the transaction status it contains. The callback structure can vary and may include unexpected values or formats; for this reason, the logic includes robust parsing, safe defaults, and traceable error handling.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- Pre-Deploy Test
  - [ ] Unit
  - [ ] Integration (Narrow)
- Post-Deploy Test
  - [ ] Isolated Microservice
  - [ ] Broader Integration
  - [ ] Acceptance
  - [ ] Performance & Load

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] PATCH - Bug fix (backwards compatible bug fixes)
- [ ] MINOR - New feature (add functionality in a backwards compatible manner)
- [ ] MAJOR - Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
