### PR TITLE
chore: [SRTP-524] remove obsolete DeactivationReason enum and related logic

### DIFF
--- a/src/main/java/it/gov/pagopa/rtp/activator/domain/payer/DeactivationReason.java
+++ b/src/main/java/it/gov/pagopa/rtp/activator/domain/payer/DeactivationReason.java
@@ -1,7 +1,0 @@
-package it.gov.pagopa.rtp.activator.domain.payer;
-
-public enum DeactivationReason {
-
-  TAKEOVER, DELETE
-
-}

--- a/src/main/java/it/gov/pagopa/rtp/activator/domain/payer/PayerRepository.java
+++ b/src/main/java/it/gov/pagopa/rtp/activator/domain/payer/PayerRepository.java
@@ -13,6 +13,6 @@ public interface PayerRepository {
     
     Mono<Payer> save(Payer payer);
 
-    Mono<Void> deactivate(Payer payer, DeactivationReason deactivationReason);
+    Mono<Void> deactivate(Payer payer);
     
 }

--- a/src/main/java/it/gov/pagopa/rtp/activator/repository/activation/ActivationDBRepository.java
+++ b/src/main/java/it/gov/pagopa/rtp/activator/repository/activation/ActivationDBRepository.java
@@ -105,7 +105,7 @@ public class ActivationDBRepository implements PayerRepository {
     return Mono.just(payer)
         .doFirst(() -> log.debug("Deactivating payer: {}", payer))
         .doOnNext(payerToDeactivate -> log.debug("Mapping payer to deleted entity."))
-        .map(payerToDeactivate -> this.activationMapper.toDeletedDbEntity(payerToDeactivate))
+        .map(this.activationMapper::toDeletedDbEntity)
 
         .doOnNext(deletedActivationEntity -> log.debug("Saving deleted entity: {}", deletedActivationEntity))
         .flatMap(this.deletedActivationDB::save)

--- a/src/main/java/it/gov/pagopa/rtp/activator/repository/activation/ActivationDBRepository.java
+++ b/src/main/java/it/gov/pagopa/rtp/activator/repository/activation/ActivationDBRepository.java
@@ -1,7 +1,6 @@
 package it.gov.pagopa.rtp.activator.repository.activation;
 
 
-import it.gov.pagopa.rtp.activator.domain.payer.DeactivationReason;
 import java.util.Objects;
 import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
@@ -94,23 +93,19 @@ public class ActivationDBRepository implements PayerRepository {
    * Deactivates a given {@link Payer}, persisting the deletion reason and removing the active record.
    *
    * @param payer               the payer to deactivate
-   * @param deactivationReason the reason for deactivation
    * @return a {@link Mono<Void>} that completes when the operation finishes
-   * @throws NullPointerException if {@code payer} or {@code deactivationReason} is {@code null}
+   * @throws NullPointerException if {@code payer} is {@code null}
    */
   @NonNull
   @Override
-  public Mono<Void> deactivate(
-      @NonNull final Payer payer,
-      @NonNull final DeactivationReason deactivationReason) {
+  public Mono<Void> deactivate(@NonNull final Payer payer) {
 
     Objects.requireNonNull(payer, "Payer cannot be null");
-    Objects.requireNonNull(deactivationReason, "Deactivation reason cannot be null");
 
     return Mono.just(payer)
         .doFirst(() -> log.debug("Deactivating payer: {}", payer))
         .doOnNext(payerToDeactivate -> log.debug("Mapping payer to deleted entity."))
-        .map(payerToDeactivate -> this.activationMapper.toDeletedDbEntity(payerToDeactivate, deactivationReason))
+        .map(payerToDeactivate -> this.activationMapper.toDeletedDbEntity(payerToDeactivate))
 
         .doOnNext(deletedActivationEntity -> log.debug("Saving deleted entity: {}", deletedActivationEntity))
         .flatMap(this.deletedActivationDB::save)

--- a/src/main/java/it/gov/pagopa/rtp/activator/repository/activation/ActivationMapper.java
+++ b/src/main/java/it/gov/pagopa/rtp/activator/repository/activation/ActivationMapper.java
@@ -1,6 +1,5 @@
 package it.gov.pagopa.rtp.activator.repository.activation;
 
-import it.gov.pagopa.rtp.activator.domain.payer.DeactivationReason;
 import java.time.Instant;
 import org.springframework.stereotype.Component;
 
@@ -50,16 +49,14 @@ public class ActivationMapper {
      * a deactivated payer in the database.
      *
      * @param payer the domain model of the payer being deactivated
-     * @param deactivationReason the reason for deactivation
      * @return the corresponding {@link DeletedActivationEntity}
      */
-    public DeletedActivationEntity toDeletedDbEntity(Payer payer, DeactivationReason deactivationReason) {
+    public DeletedActivationEntity toDeletedDbEntity(Payer payer) {
         return DeletedActivationEntity.builder()
             .id(payer.activationID().getId())
             .fiscalCode(payer.fiscalCode())
             .serviceProviderDebtor(payer.serviceProviderDebtor())
             .deactivationDate(Instant.now())
-            .reason(deactivationReason)
             .build();
     }
 }

--- a/src/main/java/it/gov/pagopa/rtp/activator/repository/activation/DeletedActivationEntity.java
+++ b/src/main/java/it/gov/pagopa/rtp/activator/repository/activation/DeletedActivationEntity.java
@@ -1,6 +1,5 @@
 package it.gov.pagopa.rtp.activator.repository.activation;
 
-import it.gov.pagopa.rtp.activator.domain.payer.DeactivationReason;
 import java.time.Instant;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
@@ -32,6 +31,4 @@ public class DeletedActivationEntity {
   @Field(name = "fiscal_code", targetType = FieldType.STRING)
   private String fiscalCode;
 
-  @Field(name = "reason", targetType = FieldType.STRING)
-  private DeactivationReason reason;
 }

--- a/src/main/java/it/gov/pagopa/rtp/activator/service/activation/ActivationPayerServiceImpl.java
+++ b/src/main/java/it/gov/pagopa/rtp/activator/service/activation/ActivationPayerServiceImpl.java
@@ -103,9 +103,9 @@ public class ActivationPayerServiceImpl implements ActivationPayerService {
         return Mono.just(payerToDeactivate)
             .doOnNext(payer -> log.info("Deactivating payer with id {}", payer.activationID().getId()))
             .flatMap(payer ->
-                this.activationDBRepository.deactivate(payer)
+                this.activationDBRepository.deactivate(payer))
             .thenReturn(payerToDeactivate)
             .doOnSuccess(id -> log.info("Payer deactivated with id {}", payerToDeactivate.activationID().getId()))
-            .doOnError(error -> log.error("Error deactivating payer: {}", error.getMessage(), error)));
+            .doOnError(error -> log.error("Error deactivating payer: {}", error.getMessage(), error));
     }
 }

--- a/src/main/java/it/gov/pagopa/rtp/activator/service/activation/ActivationPayerServiceImpl.java
+++ b/src/main/java/it/gov/pagopa/rtp/activator/service/activation/ActivationPayerServiceImpl.java
@@ -1,6 +1,5 @@
 package it.gov.pagopa.rtp.activator.service.activation;
 
-import it.gov.pagopa.rtp.activator.domain.payer.DeactivationReason;
 import java.time.Instant;
 
 import io.opentelemetry.instrumentation.annotations.WithSpan;
@@ -104,9 +103,9 @@ public class ActivationPayerServiceImpl implements ActivationPayerService {
         return Mono.just(payerToDeactivate)
             .doOnNext(payer -> log.info("Deactivating payer with id {}", payer.activationID().getId()))
             .flatMap(payer ->
-                this.activationDBRepository.deactivate(payer, DeactivationReason.DELETE))
+                this.activationDBRepository.deactivate(payer)
             .thenReturn(payerToDeactivate)
             .doOnSuccess(id -> log.info("Payer deactivated with id {}", payerToDeactivate.activationID().getId()))
-            .doOnError(error -> log.error("Error deactivating payer: {}", error.getMessage(), error));
+            .doOnError(error -> log.error("Error deactivating payer: {}", error.getMessage(), error)));
     }
 }

--- a/src/main/java/it/gov/pagopa/rtp/activator/service/activation/ActivationPayerServiceImpl.java
+++ b/src/main/java/it/gov/pagopa/rtp/activator/service/activation/ActivationPayerServiceImpl.java
@@ -102,8 +102,7 @@ public class ActivationPayerServiceImpl implements ActivationPayerService {
 
         return Mono.just(payerToDeactivate)
             .doOnNext(payer -> log.info("Deactivating payer with id {}", payer.activationID().getId()))
-            .flatMap(payer ->
-                this.activationDBRepository.deactivate(payer))
+            .flatMap(this.activationDBRepository::deactivate)
             .thenReturn(payerToDeactivate)
             .doOnSuccess(id -> log.info("Payer deactivated with id {}", payerToDeactivate.activationID().getId()))
             .doOnError(error -> log.error("Error deactivating payer: {}", error.getMessage(), error));

--- a/src/test/java/it/gov/pagopa/rtp/activator/repository/activation/ActivationMapperTest.java
+++ b/src/test/java/it/gov/pagopa/rtp/activator/repository/activation/ActivationMapperTest.java
@@ -1,6 +1,5 @@
 package it.gov.pagopa.rtp.activator.repository.activation;
 
-import it.gov.pagopa.rtp.activator.domain.payer.DeactivationReason;
 import org.junit.jupiter.api.Test;
 
 import it.gov.pagopa.rtp.activator.domain.payer.Payer;
@@ -47,7 +46,7 @@ class ActivationMapperTest {
     }
 
     @Test
-    void givenValidPayerAndReason_whenToDeletedDbEntity_thenReturnsCorrectDeletedEntity() {
+    void givenValidPayer_whenToDeletedDbEntity_thenReturnsCorrectDeletedEntity() {
         final var activationId = UUID.randomUUID();
         final var activationID = new ActivationID(activationId);
         final var fiscalCode = "MOCKXX01D01H501W";
@@ -55,15 +54,13 @@ class ActivationMapperTest {
         final var activationDate = Instant.parse("2025-01-01T00:00:00Z");
 
         final var payer = new Payer(activationID, serviceProvider, fiscalCode, activationDate);
-        final var reason = DeactivationReason.DELETE;
 
-        final var result = mapper.toDeletedDbEntity(payer, reason);
+        final var result = mapper.toDeletedDbEntity(payer);
 
         assertNotNull(result);
         assertEquals(activationId, result.getId());
         assertEquals(fiscalCode, result.getFiscalCode());
         assertEquals(serviceProvider, result.getServiceProviderDebtor());
-        assertEquals(reason, result.getReason());
         assertNotNull(result.getDeactivationDate());
     }
 }

--- a/src/test/java/it/gov/pagopa/rtp/activator/service/activation/ActivationPayerServiceImplTest.java
+++ b/src/test/java/it/gov/pagopa/rtp/activator/service/activation/ActivationPayerServiceImplTest.java
@@ -1,6 +1,5 @@
 package it.gov.pagopa.rtp.activator.service.activation;
 
-import it.gov.pagopa.rtp.activator.domain.payer.DeactivationReason;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -127,20 +126,20 @@ class ActivationPayerServiceImplTest {
     final var activationId = UUID.randomUUID();
     final var payerToDeactivate = new Payer(new ActivationID(activationId), rtpSpId, fiscalCode, Instant.now());
 
-    when(activationDBRepository.deactivate(payerToDeactivate, DeactivationReason.DELETE))
+    when(activationDBRepository.deactivate(payerToDeactivate))
         .thenReturn(Mono.empty());
 
     StepVerifier.create(activationPayerService.deactivatePayer(payerToDeactivate))
         .expectNext(payerToDeactivate)
         .verifyComplete();
 
-    verify(activationDBRepository).deactivate(payerToDeactivate, DeactivationReason.DELETE);
+    verify(activationDBRepository).deactivate(payerToDeactivate);
   }
 
   @Test
   void givenNullPayer_whenDeactivatePayer_thenThrowsNullPointerException() {
     assertThrows(NullPointerException.class, () -> activationPayerService.deactivatePayer(null));
-    verify(activationDBRepository, never()).deactivate(any(), any());
+    verify(activationDBRepository, never()).deactivate(any());
   }
 
   @Test
@@ -149,13 +148,13 @@ class ActivationPayerServiceImplTest {
     final var activationId = UUID.randomUUID();
     final var payerToDeactivate = new Payer(new ActivationID(activationId), rtpSpId, fiscalCode, Instant.now());
 
-    when(activationDBRepository.deactivate(payerToDeactivate, DeactivationReason.DELETE))
+    when(activationDBRepository.deactivate(payerToDeactivate))
         .thenReturn(Mono.error(new RuntimeException("deactivation error")));
 
     StepVerifier.create(activationPayerService.deactivatePayer(payerToDeactivate))
         .expectErrorMessage("deactivation error")
         .verify();
 
-    verify(activationDBRepository).deactivate(payerToDeactivate, DeactivationReason.DELETE);
+    verify(activationDBRepository).deactivate(payerToDeactivate);
   }
 }


### PR DESCRIPTION
#### Description
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR removes the DeactivationReason enum from the codebase, as it is no longer required for payer deactivation logic.
This change aims to keep the codebase lean and focused, avoiding unused logic and unnecessary persistence fields.

#### List of Changes
<!--- Describe your changes in detail -->

- Removed the DeactivationReason enum.
- Updated DeletedActivationEntity to no longer persist the reason field.
- Adjusted ActivationMapper to exclude the deactivation reason.
- Refactored ActivationDBRepository and ActivationPayerServiceImpl to work without the reason.
- updated related tests

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change was requested to simplify the deactivation flow.
The reason field was originally intended to distinguish between "takeover" and "delete" operations, but it's no longer used in the application logic.
Removing it helps reduce technical debt and avoids persisting unused data in the database.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- Pre-Deploy Test
  - [x] Unit
  - [x] Integration (Narrow)
- Post-Deploy Test
  - [x] Isolated Microservice
  - [ ] Broader Integration
  - [ ] Acceptance
  - [ ] Performance & Load

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] PATCH - Bug fix (backwards compatible bug fixes)
- [x] MINOR - New feature (add functionality in a backwards compatible manner)
- [ ] MAJOR - Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
