### PR TITLE
fix: [SRTP-707] Enable scan cve

### DIFF
--- a/.github/workflows/scan-cve.yml
+++ b/.github/workflows/scan-cve.yml
@@ -9,7 +9,10 @@
 name: Container Scan
 
 on:
-  workflow_call:
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ "main" ]
+  workflow_dispatch:
   schedule:
     - cron: '00 07 * * *'
 
@@ -39,14 +42,14 @@ jobs:
 
       - name: "Run the Trivy scan action itself with GitHub Advanced Security code scanning integration enabled"
         id: scan
-        uses: aquasecurity/trivy-action@18f2510ee396bbf400402947b394f2dd8c87dbb0 # v0.29.0
+        uses: aquasecurity/trivy-action@dc5a429b52fcf669ce959baa2c2dd26090d2a6c4 # v0.32.0
         with:
           image-ref: "localbuild/testimage:latest"
           format: 'sarif'
           output: 'results.sarif'
 
       - name: "Upload Anchore Scan Report"
-        uses: github/codeql-action/upload-sarif@cbe18979603527f12c7871a6eb04833ecf1548c7 # CodeQL Bundle v2.19.3
+        uses: github/codeql-action/upload-sarif@9b02dc2f60288b463e7a66e39c78829b62780db7 # CodeQL Bundle v2.22.1
         with:
           sarif_file: 'results.sarif'
 


### PR DESCRIPTION
#### Description
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
- Updated all GitHub Action dependencies to their latest secure versions
- Added trigger to run the container scan workflow on pull request events

#### Motivation and Context
This change ensures that container images used in rtp-activator are regularly scanned for vulnerabilities. It helps us catch security issues early, prevent deploying unsafe code, and maintain compliance with security standards.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- Pre-Deploy Test
  - [ ] Unit
  - [ ] Integration (Narrow)
- Post-Deploy Test
  - [x] Isolated Microservice
  - [ ] Broader Integration
  - [ ] Acceptance
  - [ ] Performance & Load

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] PATCH - Bug fix (backwards compatible bug fixes)
- [ ] MINOR - New feature (add functionality in a backwards compatible manner)
- [ ] MAJOR - Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
